### PR TITLE
[MOBILE-3542] Fix doc builds and uploads; use GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,34 +20,30 @@ jobs:
 
       - name: Get Version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+        
       - name: Verify Version
         run: |
           VERSION=${{ steps.get_version.outputs.VERSION }}
           PLUGIN_VERSION=$(./gradlew -q getVersion)
           if [[ $PLUGIN_VERSION = $VERSION ]]; then exit 0 ; else exit 1; fi
 
-      - name: Get Release Notes
+      - name: Get the release notes
         id: get_release_notes
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
         run: |
-          VERSION=${{ steps.get_version.outputs.VERSION }}
-          NOTES="$(awk "/## Version $VERSION/{flag=1;next}/## Version/{flag=0}flag" CHANGELOG.md)"
-          NOTES="${NOTES//'%'/'%25'}"
-          NOTES="${NOTES//$'\n'/'%0A'}"
-          NOTES="${NOTES//$'\r'/'%0D'}"
-          echo ::set-output name=NOTES::"$NOTES"
-
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
+          delimiter="$(openssl rand -hex 8)"
+          {
+            echo "NOTES<<${delimiter}"
+            awk "/## Version $VERSION/{flag=1;next}/## Version/{flag=0}flag" CHANGELOG.md
+            echo ${delimiter}
+          } >> $GITHUB_OUTPUT
           
-      # - name: Setup GCP
-      #   uses: google-github-actions/setup-gcloud@daadedc81d5f9d3c06d2c92f49202a3cc2b919ba # v0.2.1
-      #   with:
-      #     version: '351.0.0'
-      #     service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-      #     service_account_key: ${{ secrets.GCP_SA_KEY }}
+      - name: Setup GCP Auth
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3
@@ -64,24 +60,23 @@ jobs:
         run: |
           dotnet workload install android ios maui-android maui-ios maui-maccatalyst
 
-      # - name: Install doc dependencies
-      #   run: |
-      #     brew install doxygen
-      #     brew install graphviz
+      - name: Install doc dependencies
+        run: |
+          brew install doxygen
+          brew install graphviz
 
       - name: Build
-        #run: ./gradlew build pack packageDocs
-        run: ./gradlew build pack
+        run: ./gradlew build pack packageDocs
 
       - name: Publish Nugets
         env:
           NUGET_PRODUCTION_API_KEY: ${{ secrets.NUGET_PRODUCTION_API_KEY }}
         run: ./gradlew publishToProduction
 
-      # - name: Upload Docs
-      #   run: |
-      #     VERSION=${{ steps.get_version.outputs.VERSION }}
-      #     gsutil cp docs/build/$VERSION.tar.gz gs://ua-web-ci-prod-docs-transfer/libraries/maui/$VERSION.tar.gz
+      - name: Upload Docs
+        run: |
+          VERSION=${{ steps.get_version.outputs.VERSION }}
+          gsutil cp docs/build/$VERSION.tar.gz gs://ua-web-ci-prod-docs-transfer/libraries/maui/$VERSION.tar.gz
 
       - name: Create Github Release
         uses: actions/create-release@v1.0.1


### PR DESCRIPTION
### What do these changes do?

* Uncomments doc build and upload steps in release workflow
* Switches to `google-github-actions/auth` action in place of `setup-gcloud`
* Migrates `::set-output` usages to `$GITHUB_OUTPUT`

### Why are these changes necessary?

* Docs builds/uploads were commented out because we didn't have credentials added to the repo, previously
* set-output is deprecated and throws warnings in the actions console

