### PR TITLE
Release 17.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Airship Xamarin Changelog
 
+## Version 17.1.0 - July 24, 2023
+Minor release that updates Airship SDKs to the latest 16.x releases and fixes issues with bitcode for iOS.
+
+### Changes
+- Android SDK version 16.11.1
+- iOS SDK version 16.12.3
+
 ## Version 17.0.0 - March 17, 2023
 Major release to support MAUI. The Airship .NET SDK targets .NET 6.0, and is compatible with
 Android 5.0+ (API 21+) and iOS 13+, using the latest supported release of Xcode (currently 14.2).

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "urbanairship/ios-library" == 16.11.3
+github "urbanairship/ios-library" == 16.12.3

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,15 +5,15 @@
   <!-- Versions -->
   <PropertyGroup>
     <!-- Airship native SDK versions -->
-    <AirshipAndroidVersion>16.9.1</AirshipAndroidVersion>
-    <AirshipAndroidNugetVersion>16.9.1</AirshipAndroidNugetVersion>
+    <AirshipAndroidVersion>16.11.1</AirshipAndroidVersion>
+    <AirshipAndroidNugetVersion>16.11.1</AirshipAndroidNugetVersion>
 
-    <AirshipIosVersion>16.11.3</AirshipIosVersion>
-    <AirshipIosNugetVersion>16.11.3</AirshipIosNugetVersion>
+    <AirshipIosVersion>16.12.3</AirshipIosVersion>
+    <AirshipIosNugetVersion>16.12.3</AirshipIosNugetVersion>
 
     <!-- Airship.Net version -->
-    <AirshipCrossPlatformVersion>17.0.0</AirshipCrossPlatformVersion>
-    <AirshipCrossPlatformNugetVersion>17.0.0</AirshipCrossPlatformNugetVersion>
+    <AirshipCrossPlatformVersion>17.1.0</AirshipCrossPlatformVersion>
+    <AirshipCrossPlatformNugetVersion>17.1.0</AirshipCrossPlatformNugetVersion>
   </PropertyGroup>
 
   <!-- Nuget packaging metadata -->

--- a/airship.properties
+++ b/airship.properties
@@ -5,6 +5,9 @@ androidVersion = 16.9.1
 # Airship.Net cross-platform version
 crossPlatformVersion = 17.0.0
 
+# Filename of the iOS SDK zip file
+iosFrameworkZip = Airship-Xcode14.zip
+
 # NuGet package revision numbers
 # If > 0, the revision number will be added to the versions
 # defined above as a 4th segment (i.e., MAJOR.MINOR.PATCH.REVISION).

--- a/airship.properties
+++ b/airship.properties
@@ -1,9 +1,9 @@
 # Airship native SDK versions
-iosVersion = 16.11.3
-androidVersion = 16.9.1
+iosVersion = 16.12.3
+androidVersion = 16.11.1
 
 # Airship.Net cross-platform version
-crossPlatformVersion = 17.0.0
+crossPlatformVersion = 17.1.0
 
 # Filename of the iOS SDK zip file
 iosFrameworkZip = Airship-Xcode14.zip

--- a/binderator/build.gradle.kts
+++ b/binderator/build.gradle.kts
@@ -80,8 +80,17 @@ tasks {
   }
 
   register<Delete>("clean") {
-    delete(file("build").listFiles())
-    delete(file("externals").listFiles())
-    delete(file(binderatorGeneratedDir).listFiles())
+    val buildDir = file("build")
+    if (buildDir.exists()) {
+      delete(buildDir.listFiles())
+    }
+
+    val externalsDir = file("externals")
+    delete(externalsDir.listFiles())
+
+    val generatedDir = file(binderatorGeneratedDir)
+    if (generatedDir.exists()) {
+      delete(generatedDir.listFiles())
+    }
   }
 }

--- a/binderator/config.json
+++ b/binderator/config.json
@@ -17,56 +17,56 @@
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-adm",
-        "version": "16.9.1",
-        "nugetVersion": "16.9.1",
+        "version": "16.11.1",
+        "nugetVersion": "16.11.1",
         "nugetId": "Airship.Net.Android.Adm",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-automation",
-        "version": "16.9.1",
-        "nugetVersion": "16.9.1",
+        "version": "16.11.1",
+        "nugetVersion": "16.11.1",
         "nugetId": "Airship.Net.Android.Automation",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-core",
-        "version": "16.9.1",
-        "nugetVersion": "16.9.1",
+        "version": "16.11.1",
+        "nugetVersion": "16.11.1",
         "nugetId": "Airship.Net.Android.Core",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-fcm",
-        "version": "16.9.1",
-        "nugetVersion": "16.9.1",
+        "version": "16.11.1",
+        "nugetVersion": "16.11.1",
         "nugetId": "Airship.Net.Android.Fcm",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-layout",
-        "version": "16.9.1",
-        "nugetVersion": "16.9.1",
+        "version": "16.11.1",
+        "nugetVersion": "16.11.1",
         "nugetId": "Airship.Net.Android.Layout",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-message-center",
-        "version": "16.9.1",
-        "nugetVersion": "16.9.1",
+        "version": "16.11.1",
+        "nugetVersion": "16.11.1",
         "nugetId": "Airship.Net.Android.MessageCenter",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-preference-center",
-        "version": "16.9.1",
-        "nugetVersion": "16.9.1",
+        "version": "16.11.1",
+        "nugetVersion": "16.11.1",
         "nugetId": "Airship.Net.Android.PreferenceCenter",
         "dependencyOnly": false
       },

--- a/src/Airship.Net.MessageCenter/Airship.Net.MessageCenter.csproj
+++ b/src/Airship.Net.MessageCenter/Airship.Net.MessageCenter.csproj
@@ -8,6 +8,7 @@
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<RootNamespace>AirshipDotNet.MessageCenter</RootNamespace>
+		<IsTrimmable>false</IsTrimmable>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">13.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>

--- a/src/Airship.Net.MessageCenter/AirshipMessageCenter.cs
+++ b/src/Airship.Net.MessageCenter/AirshipMessageCenter.cs
@@ -7,14 +7,14 @@ using AirshipDotNet.MessageCenter.Handlers;
 
 namespace AirshipDotNet.MessageCenter
 {
-  /// <summary>
-  /// Helper extensions to allow easy integration of Airship's built-in UIs.
-  /// </summary>
+	/// <summary>
+	/// Helper extensions to allow easy integration of Airship's built-in UIs.
+	/// </summary>
 	public static class MauiAppBuilderExtensions
 	{
-    /// <summary>
-    /// <c>MauiAppBuilder</c> extension that configures Airship Message Center handlers.
-    /// </summary>
+		/// <summary>
+		/// <c>MauiAppBuilder</c> extension that configures Airship Message Center handlers.
+		/// </summary>
 		public static MauiAppBuilder UseAirshipMessageCenter(this MauiAppBuilder builder)
 		{
 			builder.ConfigureMauiHandlers((h) => {

--- a/src/Airship.Net.MessageCenter/Handlers/MessageViewHandler.Android.cs
+++ b/src/Airship.Net.MessageCenter/Handlers/MessageViewHandler.Android.cs
@@ -12,6 +12,7 @@ namespace AirshipDotNet.MessageCenter.Handlers;
 /// <summary>
 /// Handler responsible for displaying a single Message Center message via the platform MessageWebView.
 /// </summary>
+[Preserve(AllMembers = true)]
 public partial class MessageViewHandler : ViewHandler<IMessageView, MessageWebView>
 {
     private UrbanAirship.MessageCenter.Message? message;

--- a/src/Airship.Net.MessageCenter/Handlers/MessageViewHandler.iOS.cs
+++ b/src/Airship.Net.MessageCenter/Handlers/MessageViewHandler.iOS.cs
@@ -12,6 +12,7 @@ namespace AirshipDotNet.MessageCenter.Handlers;
 /// <summary>
 /// Handler responsible for displaying a single Message Center message via the platform WKWebView.
 /// </summary>
+[Preserve(AllMembers = true)]
 public partial class MessageViewHandler : ViewHandler<IMessageView, WKWebView>
 {
     public static PropertyMapper<IMessageView, MessageViewHandler> MessageViewMapper = new(ViewHandler.ViewMapper)

--- a/src/Airship.Net/Airship.Net.csproj
+++ b/src/Airship.Net/Airship.Net.csproj
@@ -8,6 +8,7 @@
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<RootNamespace>AirshipDotNet</RootNamespace>
+		<IsTrimmable>false</IsTrimmable>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">13.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>

--- a/src/Airship.Net/MessageCenter/Message.cs
+++ b/src/Airship.Net/MessageCenter/Message.cs
@@ -5,6 +5,7 @@ namespace AirshipDotNet.MessageCenter
     /// <summary>
     /// A Message model object.
     /// </summary>
+    [Preserve(AllMembers = true)]
     public partial class Message
     {
         /// <summary>

--- a/src/Airship.Net/PreserveAttribute.cs
+++ b/src/Airship.Net/PreserveAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace AirshipDotNet
+{
+    /// Adds `Preserve` attribute support to control the linker.
+    [AttributeUsage(AttributeTargets.All)]
+    public sealed class PreserveAttribute : Attribute
+    {
+        public bool AllMembers;
+        public bool Conditional;
+    }
+}
+

--- a/src/AirshipBindings.iOS.Automation/AirshipBindings.iOS.Automation.csproj
+++ b/src/AirshipBindings.iOS.Automation/AirshipBindings.iOS.Automation.csproj
@@ -15,7 +15,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>
-    <IsTrimmable>true</IsTrimmable>
+    <IsTrimmable>false</IsTrimmable>
     <AssemblyVersion>$(AirshipIosVersion)</AssemblyVersion>
     <PackageVersion>$(AirshipIosNugetVersion)</PackageVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>

--- a/src/AirshipBindings.iOS.Basement/AirshipBindings.iOS.Basement.csproj
+++ b/src/AirshipBindings.iOS.Basement/AirshipBindings.iOS.Basement.csproj
@@ -15,7 +15,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>
-    <IsTrimmable>true</IsTrimmable>
+    <IsTrimmable>false</IsTrimmable>
     <AssemblyVersion>$(AirshipIosVersion)</AssemblyVersion>
     <PackageVersion>$(AirshipIosNugetVersion)</PackageVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>

--- a/src/AirshipBindings.iOS.Core/AirshipBindings.iOS.Core.csproj
+++ b/src/AirshipBindings.iOS.Core/AirshipBindings.iOS.Core.csproj
@@ -13,7 +13,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>
-    <IsTrimmable>true</IsTrimmable>
+    <IsTrimmable>false</IsTrimmable>
     <AssemblyVersion>$(AirshipIosVersion)</AssemblyVersion>
     <PackageVersion>$(AirshipIosNugetVersion)</PackageVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>

--- a/src/AirshipBindings.iOS.ExtendedActions/AirshipBindings.iOS.ExtendedActions.csproj
+++ b/src/AirshipBindings.iOS.ExtendedActions/AirshipBindings.iOS.ExtendedActions.csproj
@@ -13,7 +13,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>
-    <IsTrimmable>true</IsTrimmable>
+    <IsTrimmable>false</IsTrimmable>
     <AssemblyVersion>$(AirshipIosVersion)</AssemblyVersion>
     <PackageVersion>$(AirshipIosNugetVersion)</PackageVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>

--- a/src/AirshipBindings.iOS.MessageCenter/AirshipBindings.iOS.MessageCenter.csproj
+++ b/src/AirshipBindings.iOS.MessageCenter/AirshipBindings.iOS.MessageCenter.csproj
@@ -15,7 +15,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>
-    <IsTrimmable>true</IsTrimmable>
+    <IsTrimmable>false</IsTrimmable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyVersion>$(AirshipIosVersion)</AssemblyVersion>
     <PackageVersion>$(AirshipIosNugetVersion)</PackageVersion>

--- a/src/AirshipBindings.iOS.NotificationContentExtension/AirshipBindings.iOS.NotificationContentExtension.csproj
+++ b/src/AirshipBindings.iOS.NotificationContentExtension/AirshipBindings.iOS.NotificationContentExtension.csproj
@@ -12,7 +12,7 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <DisableExtraReferences>true</DisableExtraReferences>
     <Nullable>enable</Nullable>
-    <IsTrimmable>true</IsTrimmable>
+    <IsTrimmable>false</IsTrimmable>
     <AssemblyVersion>$(AirshipIosVersion)</AssemblyVersion>
     <PackageVersion>$(AirshipIosNugetVersion)</PackageVersion>
     <ImplicitUsings>true</ImplicitUsings>

--- a/src/AirshipBindings.iOS.NotificationServiceExtension/AirshipBindings.iOS.NotificationServiceExtension.csproj
+++ b/src/AirshipBindings.iOS.NotificationServiceExtension/AirshipBindings.iOS.NotificationServiceExtension.csproj
@@ -13,7 +13,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>
-    <IsTrimmable>true</IsTrimmable>
+    <IsTrimmable>false</IsTrimmable>
     <AssemblyVersion>$(AirshipIosVersion)</AssemblyVersion>
     <PackageVersion>$(AirshipIosNugetVersion)</PackageVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>

--- a/src/AirshipBindings.iOS.PreferenceCenter/AirshipBindings.iOS.PreferenceCenter.csproj
+++ b/src/AirshipBindings.iOS.PreferenceCenter/AirshipBindings.iOS.PreferenceCenter.csproj
@@ -13,7 +13,7 @@
     <DisableExtraReferences>true</DisableExtraReferences>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
-    <IsTrimmable>true</IsTrimmable>
+    <IsTrimmable>false</IsTrimmable>
     <AssemblyVersion>$(AirshipIosVersion)</AssemblyVersion>
     <PackageVersion>$(AirshipIosNugetVersion)</PackageVersion>
     <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>

--- a/src/AirshipBindings.iOS.PreferenceCenter/ApiDefinitions.cs
+++ b/src/AirshipBindings.iOS.PreferenceCenter/ApiDefinitions.cs
@@ -71,7 +71,8 @@ namespace UrbanAirship
 		IUAPreferenceConditions[] Conditions { get; set; }
 	}
 
-    // @interface UAPreferenceAlertItemButton : NSObject
+	// @interface UAPreferenceAlertItemButton : NSObject
+	[Preserve(AllMembers = true)]
     [BaseType(typeof(NSObject))]
 	interface UAPreferenceAlertItemButton
 	{

--- a/src/AirshipBindings.iOS.common/build.gradle
+++ b/src/AirshipBindings.iOS.common/build.gradle
@@ -24,10 +24,10 @@ task syncVersion  {
 
 task downloadFrameworks {
     doLast() {
-        def path = new File("${rootDir}/frameworks/Airship.zip")
+        def path = new File("${rootDir}/frameworks/${airshipProperties.iosFrameworkZip}")
 
         if ( !path.exists() ) {
-            def url = new URL("https://github.com/urbanairship/ios-library/releases/download/${airshipProperties.iosVersion}/Airship.zip")
+            def url = new URL("https://github.com/urbanairship/ios-library/releases/download/${airshipProperties.iosVersion}/${airshipProperties.iosFrameworkZip}")
             HttpURLConnection huc = (HttpURLConnection) url.openConnection()
             huc.setRequestMethod("GET")
             huc.connect();
@@ -41,7 +41,7 @@ task downloadFrameworks {
                 exec {
                     workingDir "${rootDir}/frameworks"
                     executable "unzip"
-                    args "-u", "Airship.zip"
+                    args "-u", "${airshipProperties.iosFrameworkZip}"
                 }
             }
         }

--- a/src/AirshipBindings.iOS/AirshipBindings.iOS.csproj
+++ b/src/AirshipBindings.iOS/AirshipBindings.iOS.csproj
@@ -10,7 +10,7 @@
     <ImplicitUsings>true</ImplicitUsings>
     <AssemblyVersion>$(AirshipIosVersion)</AssemblyVersion>
     <PackageVersion>$(AirshipIosNugetVersion)</PackageVersion>
-    <IsTrimmable>true</IsTrimmable>
+    <IsTrimmable>false</IsTrimmable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
   </PropertyGroup>

--- a/src/SharedAssemblyInfo.Common.cs
+++ b/src/SharedAssemblyInfo.Common.cs
@@ -6,4 +6,4 @@ using UrbanAirship.Attributes;
 // Change them to the values specific to your project.
 
 // Cross-platform version of the plugin
-[assembly: UACrossPlatformVersion ("17.0.0")]
+[assembly: UACrossPlatformVersion ("17.1.0")]

--- a/src/SharedAssemblyInfo.CrossPlatform.cs
+++ b/src/SharedAssemblyInfo.CrossPlatform.cs
@@ -12,5 +12,5 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("17.0.0")]
+[assembly: AssemblyVersion ("17.1.0")]
 

--- a/src/SharedAssemblyInfo.iOS.cs
+++ b/src/SharedAssemblyInfo.iOS.cs
@@ -11,11 +11,10 @@ using System.Reflection;
 // When the attribute is present, the linker—if enabled—will process the assembly
 // even if you’re using the “Link SDK assemblies only” option, which is the default for device builds.
 
-//[assembly: LinkerSafe] // commented due to: warning CS0618: 'LinkerSafeAttribute' is obsolete: Replace with:
-[assembly: System.Reflection.AssemblyMetadata ("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyMetadata ("IsTrimmable", "False")]
 
 // The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("17.0.0")]
+[assembly: AssemblyVersion ("17.1.0")]


### PR DESCRIPTION
## Version 17.1.0 - July 24, 2023
Minor release that updates Airship SDKs to the latest 16.x releases and fixes issues with bitcode for iOS.

### Changes
- Android SDK version 16.11.1
- iOS SDK version 16.12.3