### PR TITLE
[MOBILE-3861] Update Android bindings for SDK 17.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,6 @@ binderator/output
 
 # Idea folder
 .idea
+
+# VSCode folder
+.vscode

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,8 +5,8 @@
   <!-- Versions -->
   <PropertyGroup>
     <!-- Airship native SDK versions -->
-    <AirshipAndroidVersion>17.0.3</AirshipAndroidVersion>
-    <AirshipAndroidNugetVersion>17.0.3</AirshipAndroidNugetVersion>
+    <AirshipAndroidVersion>17.1.0</AirshipAndroidVersion>
+    <AirshipAndroidNugetVersion>17.1.0</AirshipAndroidNugetVersion>
 
     <AirshipIosVersion>16.12.3</AirshipIosVersion>
     <AirshipIosNugetVersion>16.12.3</AirshipIosNugetVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,15 +5,15 @@
   <!-- Versions -->
   <PropertyGroup>
     <!-- Airship native SDK versions -->
-    <AirshipAndroidVersion>16.11.1</AirshipAndroidVersion>
-    <AirshipAndroidNugetVersion>16.11.1</AirshipAndroidNugetVersion>
+    <AirshipAndroidVersion>17.0.3</AirshipAndroidVersion>
+    <AirshipAndroidNugetVersion>17.0.3</AirshipAndroidNugetVersion>
 
     <AirshipIosVersion>16.12.3</AirshipIosVersion>
     <AirshipIosNugetVersion>16.12.3</AirshipIosNugetVersion>
 
     <!-- Airship.Net version -->
-    <AirshipCrossPlatformVersion>17.1.0</AirshipCrossPlatformVersion>
-    <AirshipCrossPlatformNugetVersion>17.1.0</AirshipCrossPlatformNugetVersion>
+    <AirshipCrossPlatformVersion>18.0.0</AirshipCrossPlatformVersion>
+    <AirshipCrossPlatformNugetVersion>18.0.0</AirshipCrossPlatformNugetVersion>
   </PropertyGroup>
 
   <!-- Nuget packaging metadata -->

--- a/MauiSample.sln
+++ b/MauiSample.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 17.0.31611.283
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MauiSample", "MauiSample\MauiSample.csproj", "{470DEC7C-2A77-4E92-8A30-DA52911D9FB2}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiSample", "MauiSample\MauiSample.csproj", "{470DEC7C-2A77-4E92-8A30-DA52911D9FB2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Airship.Net.Android.Core", "binderator\generated\Airship.Net.Android.Core\Airship.Net.Android.Core.csproj", "{F4969C3B-C442-4450-9A4D-D810B200573C}"
 EndProject
@@ -15,19 +15,27 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Airship.Net.Android.Automat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Airship.Net.Android.Fcm", "binderator\generated\Airship.Net.Android.Fcm\Airship.Net.Android.Fcm.csproj", "{1E429BBE-C098-4608-BE2E-5BCFBD50D6E5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Airship.Net.iOS.Basement", "src\AirshipBindings.iOS.Basement\AirshipBindings.iOS.Basement.csproj", "{5E85A7FD-8C42-4DE6-B002-E3CC2DA529C7}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.iOS.Basement", "src\AirshipBindings.iOS.Basement\AirshipBindings.iOS.Basement.csproj", "{5E85A7FD-8C42-4DE6-B002-E3CC2DA529C7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Airship.Net.iOS.Core", "src\AirshipBindings.iOS.Core\AirshipBindings.iOS.Core.csproj", "{7F49C0FA-F958-44CF-9246-8B8577748E6F}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.iOS.Core", "src\AirshipBindings.iOS.Core\AirshipBindings.iOS.Core.csproj", "{7F49C0FA-F958-44CF-9246-8B8577748E6F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Airship.Net.iOS.Automation", "src\AirshipBindings.iOS.Automation\AirshipBindings.iOS.Automation.csproj", "{70434FB5-A468-4777-9478-DD2AB80BE0E2}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.iOS.Automation", "src\AirshipBindings.iOS.Automation\AirshipBindings.iOS.Automation.csproj", "{70434FB5-A468-4777-9478-DD2AB80BE0E2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Airship.Net.iOS.MessageCenter", "src\AirshipBindings.iOS.MessageCenter\AirshipBindings.iOS.MessageCenter.csproj", "{AC22EEC5-DCA6-49D3-8B37-533B5565E2CF}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.iOS.MessageCenter", "src\AirshipBindings.iOS.MessageCenter\AirshipBindings.iOS.MessageCenter.csproj", "{AC22EEC5-DCA6-49D3-8B37-533B5565E2CF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Airship.Net.iOS.ExtendedActions", "src\AirshipBindings.iOS.ExtendedActions\AirshipBindings.iOS.ExtendedActions.csproj", "{BFFFE653-04CD-4563-BF2D-B6F31349F30D}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.iOS.ExtendedActions", "src\AirshipBindings.iOS.ExtendedActions\AirshipBindings.iOS.ExtendedActions.csproj", "{BFFFE653-04CD-4563-BF2D-B6F31349F30D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Airship.Net.Android.PreferenceCenter", "binderator\generated\Airship.Net.Android.PreferenceCenter\Airship.Net.Android.PreferenceCenter.csproj", "{D20DD1BB-7DF5-49C8-B8C1-E0905D273203}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Airship.Net.iOS.PreferenceCenter", "src\AirshipBindings.iOS.PreferenceCenter\AirshipBindings.iOS.PreferenceCenter.csproj", "{13E9ACF2-4FE5-4FA6-96C4-BDFB6FF7C3A0}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.iOS.PreferenceCenter", "src\AirshipBindings.iOS.PreferenceCenter\AirshipBindings.iOS.PreferenceCenter.csproj", "{13E9ACF2-4FE5-4FA6-96C4-BDFB6FF7C3A0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Airship.Net.Android.LiveUpdate", "binderator\generated\Airship.Net.Android.LiveUpdate\Airship.Net.Android.LiveUpdate.csproj", "{A7F248E6-9C79-4267-9779-2CB3AEFAD359}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Airship.Net.Android.FeatureFlag", "binderator\generated\Airship.Net.Android.FeatureFlag\Airship.Net.Android.FeatureFlag.csproj", "{16AA94F3-6A70-49EB-A82C-FDD7BBC9DFD8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Airship.Net", "src\Airship.Net\Airship.Net.csproj", "{C5F41BE2-E93A-40DA-BB41-5095249363F7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Airship.Net.MessageCenter", "src\Airship.Net.MessageCenter\Airship.Net.MessageCenter.csproj", "{4E15CB6E-1C86-47DF-8A8E-5BA7949E04B9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -89,6 +97,22 @@ Global
 		{13E9ACF2-4FE5-4FA6-96C4-BDFB6FF7C3A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{13E9ACF2-4FE5-4FA6-96C4-BDFB6FF7C3A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{13E9ACF2-4FE5-4FA6-96C4-BDFB6FF7C3A0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A7F248E6-9C79-4267-9779-2CB3AEFAD359}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7F248E6-9C79-4267-9779-2CB3AEFAD359}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7F248E6-9C79-4267-9779-2CB3AEFAD359}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7F248E6-9C79-4267-9779-2CB3AEFAD359}.Release|Any CPU.Build.0 = Release|Any CPU
+		{16AA94F3-6A70-49EB-A82C-FDD7BBC9DFD8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{16AA94F3-6A70-49EB-A82C-FDD7BBC9DFD8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{16AA94F3-6A70-49EB-A82C-FDD7BBC9DFD8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{16AA94F3-6A70-49EB-A82C-FDD7BBC9DFD8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C5F41BE2-E93A-40DA-BB41-5095249363F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C5F41BE2-E93A-40DA-BB41-5095249363F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C5F41BE2-E93A-40DA-BB41-5095249363F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C5F41BE2-E93A-40DA-BB41-5095249363F7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E15CB6E-1C86-47DF-8A8E-5BA7949E04B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E15CB6E-1C86-47DF-8A8E-5BA7949E04B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E15CB6E-1C86-47DF-8A8E-5BA7949E04B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E15CB6E-1C86-47DF-8A8E-5BA7949E04B9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MauiSample/HomePageViewModel.cs
+++ b/MauiSample/HomePageViewModel.cs
@@ -62,7 +62,7 @@ namespace MauiSample
             OnPrefCenterButtonClicked = new Command(PerformOnPrefCenterButtonClicked);
 
             Airship.Instance.OnChannelCreation += OnChannelEvent;
-            Airship.Instance.OnChannelUpdate += OnChannelEvent;
+            Airship.Instance.OnPushNotificationStatusUpdate += OnPushNotificationStatusEvent;
 
             Refresh();
         }
@@ -70,11 +70,12 @@ namespace MauiSample
         ~HomePageViewModel()
         {
             Airship.Instance.OnChannelCreation -= OnChannelEvent;
-            Airship.Instance.OnChannelUpdate -= OnChannelEvent;
         }
       
         private void OnChannelEvent(object sender, EventArgs e) => Refresh();
-            
+
+        private void OnPushNotificationStatusEvent(object sender, EventArgs e) => Refresh();
+
         public void Refresh()
         {
             ChannelId = Airship.Instance.ChannelId;

--- a/MauiSample/MauiSample.csproj
+++ b/MauiSample/MauiSample.csproj
@@ -47,11 +47,19 @@
     <!-- Controls whether to use project references or nuget packages for Airship dependencies. -->
     <!-- While developing, switch to project references to allow all code to be editied. -->
     <!-- Once finished, run the 'pack' and 'createLocalFeed' Gradle tasks and switch back to package refs. -->
-    <UseProjectReferences>false</UseProjectReferences>
+    <UseProjectReferences>true</UseProjectReferences>
   </PropertyGroup>
 
   <!-- Package dependencies -->
 
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>false</Optimize>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0-android|AnyCPU'">
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
+  </PropertyGroup>
   <ItemGroup Label="Common Package Dependencies" Condition="!$(UseProjectReferences)">
     <PackageReference Include="Airship.Net" Version="$(AirshipCrossPlatformNugetVersion)" />
     <PackageReference Include="Airship.Net.MessageCenter" Version="$(AirshipCrossPlatformNugetVersion)" />
@@ -73,6 +81,8 @@
     <PackageReference Include="Airship.Net.Android.Fcm" Version="$(AirshipAndroidNugetVersion)" />
     <PackageReference Include="Airship.Net.Android.Automation" Version="$(AirshipAndroidNugetVersion)" />
     <PackageReference Include="Airship.Net.Android.Preferencecenter" Version="$(AirshipAndroidNugetVersion)" />
+    <PackageReference Include="Airship.Net.Android.LiveUpdate" Version="$(AirshipAndroidNugetVersion)" />
+    <PackageReference Include="Airship.Net.Android.FeatureFlag" Version="$(AirshipAndroidNugetVersion)" />
   </ItemGroup>
 
   <!-- Project dependencies -->
@@ -98,6 +108,8 @@
     <ProjectReference Include="..\binderator\generated\Airship.Net.Android.MessageCenter\Airship.Net.Android.MessageCenter.csproj" />
     <ProjectReference Include="..\binderator\generated\Airship.Net.Android.PreferenceCenter\Airship.Net.Android.PreferenceCenter.csproj" />
     <ProjectReference Include="..\binderator\generated\Airship.Net.Android.Fcm\Airship.Net.Android.Fcm.csproj" />
+    <ProjectReference Include="..\binderator\generated\Airship.Net.Android.LiveUpdate\Airship.Net.Android.LiveUpdate.csproj" />
+    <ProjectReference Include="..\binderator\generated\Airship.Net.Android.FeatureFlag\Airship.Net.Android.FeatureFlag.csproj" />
   </ItemGroup>
 
   <!-- Removes -->

--- a/MauiSample/MauiSample.csproj
+++ b/MauiSample/MauiSample.csproj
@@ -47,7 +47,7 @@
     <!-- Controls whether to use project references or nuget packages for Airship dependencies. -->
     <!-- While developing, switch to project references to allow all code to be editied. -->
     <!-- Once finished, run the 'pack' and 'createLocalFeed' Gradle tasks and switch back to package refs. -->
-    <UseProjectReferences>true</UseProjectReferences>
+    <UseProjectReferences>false</UseProjectReferences>
   </PropertyGroup>
 
   <!-- Package dependencies -->

--- a/airship.properties
+++ b/airship.properties
@@ -1,12 +1,12 @@
 # Airship native SDK versions
 iosVersion = 16.12.3
-androidVersion = 16.11.1
+androidVersion = 17.0.3
 
 # Airship.Net cross-platform version
-crossPlatformVersion = 17.1.0
+crossPlatformVersion = 18.0.0
 
 # Filename of the iOS SDK zip file
-iosFrameworkZip = Airship-Xcode14.zip
+iosFrameworkZip = Airship.zip
 
 # NuGet package revision numbers
 # If > 0, the revision number will be added to the versions

--- a/airship.properties
+++ b/airship.properties
@@ -1,6 +1,6 @@
 # Airship native SDK versions
 iosVersion = 16.12.3
-androidVersion = 17.0.3
+androidVersion = 17.1.0
 
 # Airship.Net cross-platform version
 crossPlatformVersion = 18.0.0

--- a/binderator/config.json
+++ b/binderator/config.json
@@ -17,56 +17,56 @@
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-adm",
-        "version": "16.11.1",
-        "nugetVersion": "16.11.1",
+        "version": "17.0.3",
+        "nugetVersion": "17.0.3",
         "nugetId": "Airship.Net.Android.Adm",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-automation",
-        "version": "16.11.1",
-        "nugetVersion": "16.11.1",
+        "version": "17.0.3",
+        "nugetVersion": "17.0.3",
         "nugetId": "Airship.Net.Android.Automation",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-core",
-        "version": "16.11.1",
-        "nugetVersion": "16.11.1",
+        "version": "17.0.3",
+        "nugetVersion": "17.0.3",
         "nugetId": "Airship.Net.Android.Core",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-fcm",
-        "version": "16.11.1",
-        "nugetVersion": "16.11.1",
+        "version": "17.0.3",
+        "nugetVersion": "17.0.3",
         "nugetId": "Airship.Net.Android.Fcm",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-layout",
-        "version": "16.11.1",
-        "nugetVersion": "16.11.1",
+        "version": "17.0.3",
+        "nugetVersion": "17.0.3",
         "nugetId": "Airship.Net.Android.Layout",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-message-center",
-        "version": "16.11.1",
-        "nugetVersion": "16.11.1",
+        "version": "17.0.3",
+        "nugetVersion": "17.0.3",
         "nugetId": "Airship.Net.Android.MessageCenter",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-preference-center",
-        "version": "16.11.1",
-        "nugetVersion": "16.11.1",
+        "version": "17.0.3",
+        "nugetVersion": "17.0.3",
         "nugetId": "Airship.Net.Android.PreferenceCenter",
         "dependencyOnly": false
       },
@@ -169,7 +169,7 @@
       {
         "groupId": "androidx.room",
         "artifactId": "room-runtime",
-        "version": "2.5.0",
+        "version": "2.5.1",
         "nugetVersion": "2.5.0",
         "nugetId": "Xamarin.AndroidX.Room.Runtime",
         "dependencyOnly": true

--- a/binderator/config.json
+++ b/binderator/config.json
@@ -17,56 +17,72 @@
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-adm",
-        "version": "17.0.3",
-        "nugetVersion": "17.0.3",
+        "version": "17.1.0",
+        "nugetVersion": "17.1.0",
         "nugetId": "Airship.Net.Android.Adm",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-automation",
-        "version": "17.0.3",
-        "nugetVersion": "17.0.3",
+        "version": "17.1.0",
+        "nugetVersion": "17.1.0",
         "nugetId": "Airship.Net.Android.Automation",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-core",
-        "version": "17.0.3",
-        "nugetVersion": "17.0.3",
+        "version": "17.1.0",
+        "nugetVersion": "17.1.0",
         "nugetId": "Airship.Net.Android.Core",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-fcm",
-        "version": "17.0.3",
-        "nugetVersion": "17.0.3",
+        "version": "17.1.0",
+        "nugetVersion": "17.1.0",
         "nugetId": "Airship.Net.Android.Fcm",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
+        "artifactId": "urbanairship-feature-flag",
+        "version": "17.1.0",
+        "nugetVersion": "17.1.0",
+        "nugetId": "Airship.Net.Android.FeatureFlag",
+        "dependencyOnly": false
+      },
+      {
+        "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-layout",
-        "version": "17.0.3",
-        "nugetVersion": "17.0.3",
+        "version": "17.1.0",
+        "nugetVersion": "17.1.0",
         "nugetId": "Airship.Net.Android.Layout",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
+        "artifactId": "urbanairship-live-update",
+        "version": "17.1.0",
+        "nugetVersion": "17.1.0",
+        "nugetId": "Airship.Net.Android.LiveUpdate",
+        "dependencyOnly": false
+      },
+      {
+        "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-message-center",
-        "version": "17.0.3",
-        "nugetVersion": "17.0.3",
+        "version": "17.1.0",
+        "nugetVersion": "17.1.0",
         "nugetId": "Airship.Net.Android.MessageCenter",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-preference-center",
-        "version": "17.0.3",
-        "nugetVersion": "17.0.3",
+        "version": "17.1.0",
+        "nugetVersion": "17.1.0",
         "nugetId": "Airship.Net.Android.PreferenceCenter",
         "dependencyOnly": false
       },
@@ -164,6 +180,14 @@
         "version": "1.2.1",
         "nugetVersion": "1.2.1.9",
         "nugetId": "Xamarin.AndroidX.RecyclerView",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "androidx.room",
+        "artifactId": "room-ktx",
+        "version": "2.5.1",
+        "nugetVersion": "2.5.0",
+        "nugetId": "Xamarin.AndroidX.Room.Room.Ktx",
         "dependencyOnly": true
       },
       {

--- a/binderator/source/AndroidProject.cshtml
+++ b/binderator/source/AndroidProject.cshtml
@@ -39,6 +39,12 @@
       case "urbanairship-automation":
         title += " - Automation";
         break;
+      case "urbanairship-live-update":
+        title += " - Live Updates";
+        break;
+      case "urbanairship-feature-flag":
+        title += " - Feature Flags";
+        break;
       case "urbanairship-layout":
       case "urbanairship-core":
         // Use default title

--- a/binderator/source/com.urbanairship.android/urbanairship-feature-flag/Transforms/EnumFields.xml
+++ b/binderator/source/com.urbanairship.android/urbanairship-feature-flag/Transforms/EnumFields.xml
@@ -1,0 +1,2 @@
+﻿<enum-field-mappings>
+</enum-field-mappings>

--- a/binderator/source/com.urbanairship.android/urbanairship-feature-flag/Transforms/EnumMethods.xml
+++ b/binderator/source/com.urbanairship.android/urbanairship-feature-flag/Transforms/EnumMethods.xml
@@ -1,0 +1,2 @@
+﻿<enum-method-mappings>
+</enum-method-mappings>

--- a/binderator/source/com.urbanairship.android/urbanairship-feature-flag/Transforms/Metadata.xml
+++ b/binderator/source/com.urbanairship.android/urbanairship-feature-flag/Transforms/Metadata.xml
@@ -1,0 +1,3 @@
+﻿<metadata>
+</metadata>
+

--- a/binderator/source/com.urbanairship.android/urbanairship-live-update/Transforms/EnumFields.xml
+++ b/binderator/source/com.urbanairship.android/urbanairship-live-update/Transforms/EnumFields.xml
@@ -1,0 +1,2 @@
+﻿<enum-field-mappings>
+</enum-field-mappings>

--- a/binderator/source/com.urbanairship.android/urbanairship-live-update/Transforms/EnumMethods.xml
+++ b/binderator/source/com.urbanairship.android/urbanairship-live-update/Transforms/EnumMethods.xml
@@ -1,0 +1,2 @@
+﻿<enum-method-mappings>
+</enum-method-mappings>

--- a/binderator/source/com.urbanairship.android/urbanairship-live-update/Transforms/Metadata.xml
+++ b/binderator/source/com.urbanairship.android/urbanairship-live-update/Transforms/Metadata.xml
@@ -1,0 +1,4 @@
+﻿<metadata>
+  <remove-node path="/api/package[@name='com.urbanairship.liveupdate.data']"/>
+</metadata>
+

--- a/src/Airship.Net/IAirship.cs
+++ b/src/Airship.Net/IAirship.cs
@@ -1,5 +1,6 @@
 ﻿/* Copyright Airship and Contributors */
 
+using System;
 using AirshipDotNet.Attributes;
 using AirshipDotNet.Channel;
 
@@ -7,7 +8,7 @@ namespace AirshipDotNet
 {
 
     /// <summary>
-    /// Arguments for Channel creation and update events.
+    /// Arguments for Channel creation events.
     /// </summary>
     public class ChannelEventArgs : EventArgs
     {
@@ -16,6 +17,67 @@ namespace AirshipDotNet
         public ChannelEventArgs(string channelId)
         {
             ChannelId = channelId;
+        }
+    }
+
+    /// <summary>
+    /// Arguments for push notification status update events.
+    /// </summary>
+    public class PushNotificationStatusEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Indicatees whether user notifications are enabled via <c>PushManager</c>.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if user notifications are enabled, else <c>false</c>.
+        /// </value>
+        public bool IsUserNotificationsEnabled { get; private set; }
+
+        /// <summary>
+        /// Indicates whether notifications are allowed for the application at the system level.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if notifications are allowed, else <c>false</c>.
+        /// </value>
+        public bool AreNotificationsAllowed { get; private set; }
+
+        /// <summary>
+        /// Indicates whether <c>Features.Push</c> is enabled via <c>PrivacyManager</c>.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the push feature is enabled, else <c>false</c>.
+        /// </value>
+        public bool IsPushPrivacyFeatureEnabled { get; private set; }
+
+        /// <summary>
+        /// Indicates whether the application has successfully registered a push token.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if a token was received and registered, else <c>false</c>.
+        /// </value>
+        public bool IsPushTokenRegistered { get; private set; }
+
+        /// <summary>
+        /// Checks if <c>IsUserNotificationsEnabled</c>, <c>AreNotificationsAllowed</c>, and <c>IsPushPrivacyFeatureEnabled</c> is enabled.
+        /// </summary>
+        public bool IsUserOptedIn { get; private set; }
+
+        /// <summary>
+        /// Checks if <c>IsUserOptedIn</c> and <c>IsPushTokenRegistered</c> is enabled.
+        /// </summary>
+        public bool IsOptIn { get; private set; }
+
+        /// <summary>
+        /// Creates push notification status event args.
+        /// </summary>
+        public PushNotificationStatusEventArgs(bool isUserNotificationsEnabled, bool areNotificationsAllowed, bool isPushPrivacyFeatureEnabled, bool isPushTokenRegistered, bool isUserOptedIn, bool isOptIn)
+        {
+            IsUserNotificationsEnabled = isUserNotificationsEnabled;
+            AreNotificationsAllowed = areNotificationsAllowed;
+            IsPushPrivacyFeatureEnabled = isPushPrivacyFeatureEnabled;
+            IsPushTokenRegistered = isPushTokenRegistered;
+            IsUserOptedIn = isUserOptedIn;
+            IsOptIn = isOptIn;
         }
     }
 
@@ -128,10 +190,10 @@ namespace AirshipDotNet
         event EventHandler<ChannelEventArgs> OnChannelCreation;
 
         /// <summary>
-        /// Add/remove the channel update event listener.
+        /// Add/remove the push notification status listener.
         /// </summary>
-        /// <value>The channel update event listener.</value>
-        event EventHandler<ChannelEventArgs> OnChannelUpdate;
+        /// <value>The push notification status listener.</value>
+        event EventHandler<PushNotificationStatusEventArgs> OnPushNotificationStatusUpdate;
 
         /// <summary>
         /// Add/remove the deep link event listener.

--- a/src/Airship.Net/IAirship.cs
+++ b/src/Airship.Net/IAirship.cs
@@ -53,12 +53,12 @@ namespace AirshipDotNet
         InAppAutomation = 1 << 0,
         MessageCenter = 1 << 1,
         Push = 1 << 2,
-        Chat = 1 << 3,
+        //RETIRED: Chat = 1 << 3,
         Analytics = 1 << 4,
         TagsAndAttributes = 1 << 5,
         Contacts = 1 << 6,
-        Location = 1 << 7,
-        All = InAppAutomation | MessageCenter | Push | Chat | Analytics | TagsAndAttributes | Contacts | Location
+        //RETIRED: Location = 1 << 7,
+        All = InAppAutomation | MessageCenter | Push | Analytics | TagsAndAttributes | Contacts
     }
 
     /// <summary>

--- a/src/Airship.Net/Platforms/Android/Airship.cs
+++ b/src/Airship.Net/Platforms/Android/Airship.cs
@@ -115,10 +115,6 @@ namespace AirshipDotNet
             {
                 uAFeatures.Add(PrivacyManager.FeaturePush);
             }
-            if (features.HasFlag(Features.Chat))
-            {
-                uAFeatures.Add(PrivacyManager.FeatureChat);
-            }
             if (features.HasFlag(Features.Analytics))
             {
                 uAFeatures.Add(PrivacyManager.FeatureAnalytics);
@@ -130,10 +126,6 @@ namespace AirshipDotNet
             if (features.HasFlag(Features.Contacts))
             {
                 uAFeatures.Add(PrivacyManager.FeatureContacts);
-            }
-            if (features.HasFlag(Features.Location))
-            {
-                uAFeatures.Add(PrivacyManager.FeatureLocation);
             }
 
             return uAFeatures.ToArray();
@@ -158,11 +150,6 @@ namespace AirshipDotNet
                 features |= Features.Push;
             }
 
-            if ((uAFeatures & PrivacyManager.FeatureChat) == PrivacyManager.FeatureChat)
-            {
-                features |= Features.Chat;
-            }
-
             if ((uAFeatures & PrivacyManager.FeatureAnalytics) == PrivacyManager.FeatureAnalytics)
             {
                 features |= Features.Analytics;
@@ -176,11 +163,6 @@ namespace AirshipDotNet
             if ((uAFeatures & PrivacyManager.FeatureContacts) == PrivacyManager.FeatureContacts)
             {
                 features |= Features.Contacts;
-            }
-
-            if ((uAFeatures & PrivacyManager.FeatureLocation) == PrivacyManager.FeatureLocation)
-            {
-                features |= Features.Location;
             }
 
             return features;

--- a/src/Airship.Net/Platforms/iOS/Airship.cs
+++ b/src/Airship.Net/Platforms/iOS/Airship.cs
@@ -135,10 +135,6 @@ namespace AirshipDotNet
             {
                 uAFeatures |= UAFeatures.Push;
             }
-            if (features.HasFlag(Features.Chat))
-            {
-                uAFeatures |= UAFeatures.Chat;
-            }
             if (features.HasFlag(Features.Analytics))
             {
                 uAFeatures |= UAFeatures.Analytics;
@@ -150,10 +146,6 @@ namespace AirshipDotNet
             if (features.HasFlag(Features.Contacts))
             {
                 uAFeatures |= UAFeatures.Contacts;
-            }
-            if (features.HasFlag(Features.Location))
-            {
-                uAFeatures |= UAFeatures.Location;
             }
 
             return uAFeatures;
@@ -175,10 +167,6 @@ namespace AirshipDotNet
             {
                 features |= Features.Push;
             }
-            if (uAFeatures.HasFlag(UAFeatures.Chat))
-            {
-                features |= Features.Chat;
-            }
             if (uAFeatures.HasFlag(UAFeatures.Analytics))
             {
                 features |= Features.Analytics;
@@ -190,10 +178,6 @@ namespace AirshipDotNet
             if (uAFeatures.HasFlag(UAFeatures.Contacts))
             {
                 features |= Features.Contacts;
-            }
-            if (uAFeatures.HasFlag(UAFeatures.Location))
-            {
-                features |= Features.Location;
             }
 
             return features;

--- a/src/Airship.Net/Platforms/iOS/Airship.cs
+++ b/src/Airship.Net/Platforms/iOS/Airship.cs
@@ -35,15 +35,9 @@ namespace AirshipDotNet
                 }
             });
 
-            NSNotificationCenter.DefaultCenter.AddObserver(aName: (NSString)UAChannel.ChannelUpdatedEvent, (NSNotification notification) =>
-            {
-                var userInfo = notification.UserInfo;
-                if (userInfo is not null)
-                {
-                    var channelID = userInfo[UAChannel.ChannelIdentifierKey].ToString();
-                    OnChannelUpdate?.Invoke(this, new ChannelEventArgs(channelID));
-                }
-            });
+            // TODO(18.0.0): Observe updates from Push notificationStatusPublisher and
+            //               wire up to OnPushNotificationStatusUpdate once iOS SDK bindings have been updated
+
 
             //Adding Inbox updated Listener
             NSNotificationCenter.DefaultCenter.AddObserver(aName: (NSString)"com.urbanairship.notification.message_list_updated", (notification) =>
@@ -54,7 +48,7 @@ namespace AirshipDotNet
 
         public event EventHandler<ChannelEventArgs>? OnChannelCreation;
 
-        public event EventHandler<ChannelEventArgs>? OnChannelUpdate;
+        public event EventHandler<PushNotificationStatusEventArgs>? OnPushNotificationStatusUpdate;
 
         private EventHandler<DeepLinkEventArgs>? onDeepLinkReceived;
         public event EventHandler<DeepLinkEventArgs> OnDeepLinkReceived

--- a/src/AirshipBindings.iOS.Basement/StructsAndEnums.cs
+++ b/src/AirshipBindings.iOS.Basement/StructsAndEnums.cs
@@ -52,12 +52,12 @@ namespace UrbanAirship {
         InAppAutomation = (1 << 0),
         MessageCenter = (1 << 1),
         Push = (1 << 2),
-        Chat = (1 << 3),
+        //RETIRED: Chat = (1 << 3),
         Analytics = (1 << 4),
         TagsAndAttributes = (1 << 5),
         Contacts = (1 << 6),
-        Location = (1 << 7),
-        All = (InAppAutomation | MessageCenter | Push | Chat | Analytics | TagsAndAttributes | Contacts | Location)
+        //RETIRED: Location = (1 << 7),
+        All = (InAppAutomation | MessageCenter | Push | Analytics | TagsAndAttributes | Contacts )
     }
 
     [Native]

--- a/src/SharedAssemblyInfo.Common.cs
+++ b/src/SharedAssemblyInfo.Common.cs
@@ -6,4 +6,4 @@ using UrbanAirship.Attributes;
 // Change them to the values specific to your project.
 
 // Cross-platform version of the plugin
-[assembly: UACrossPlatformVersion ("17.1.0")]
+[assembly: UACrossPlatformVersion ("18.0.0")]

--- a/src/SharedAssemblyInfo.CrossPlatform.cs
+++ b/src/SharedAssemblyInfo.CrossPlatform.cs
@@ -12,5 +12,5 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("17.1.0")]
+[assembly: AssemblyVersion ("18.0.0")]
 

--- a/src/SharedAssemblyInfo.iOS.cs
+++ b/src/SharedAssemblyInfo.iOS.cs
@@ -17,4 +17,4 @@ using System.Reflection;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("17.1.0")]
+[assembly: AssemblyVersion ("18.0.0")]


### PR DESCRIPTION
### What do these changes do?

* Updates to latest Android SDK (17.1.0)
* Adds bindings for Android `feature-flag` and `live-update` modules
* Stubs out new PushNotificationStatusListener and wire up in example app (and added a TODO on the iOS side)

### Why are these changes necessary?

SDK 17 updates

### How did you verify these changes?

* Updated bindings and status listener were tested in the sample app
* I haven't tested the FF or LU modules yet, so we'll still need to do that before this is ready for release.
    * I think we should probably wrap Feature Flags in the Airship.Net (cross-platform) layer, but we'll need to update the iOS bindings first
