### PR TITLE
[MOBILE-4102] Fix iOS custom event properties, Android contact subscriptions editing, etc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: CI
 on: [pull_request]
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_15.0.app
+  DEVELOPER_DIR: /Applications/Xcode_15.1.app
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+*"
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_15.0.app
+  DEVELOPER_DIR: /Applications/Xcode_15.1.app
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Airship DotNet Changelog
 
 ## Version 19.1.0 - Jan 25, 2024
-Minor release that updates to Airship SDK 17.7.1, fixes an iOS custom event properties reporting issue, and Android contact subscription list editing. Apps that target iOS and make use of custom events or Android and make use of contact subscription editing should update.
+Minor release that updates to Airship SDK to iOS 17.7.3 and Android 17.7.2, fixes an iOS custom event properties reporting issue, and Android contact subscription list editing. Apps that target iOS and make use of custom events or Android and make use of contact subscription editing should update.
 
 ### Changes
-- Updated iOS SDK to 17.7.1
-- Updated Android SDK to 17.7.1
+- Updated iOS SDK to 17.7.3
+- Updated Android SDK to 17.7.2
 - Fixed a bug that prevented custom event properties from being reported on iOS
 - Fixed contact subscription list updates (`EditContactSubscriptionLists`) on Android
 - Deprecated iOS `Trace` log level and add the replacement `Verbose` log level.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Airship DotNet Changelog
 
-## Version 19.1.0 - Jan 24, 2024
+## Version 19.1.0 - Jan 25, 2024
 Minor release that updates to Airship SDK 17.7.1, fixes an iOS custom event properties reporting issue, and Android contact subscription list editing. Apps that target iOS and make use of custom events or Android and make use of contact subscription editing should update.
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,26 @@
 # Airship DotNet Changelog
 
+## Version 19.1.0 - Jan 24, 2024
+Minor release that updates to Airship SDK 17.7.1, fixes an iOS custom event properties reporting issue, and Android contact subscription list editing. Apps that target iOS and make use of custom events or Android and make use of contact subscription editing should update.
+
+### Changes
+- Updated iOS SDK to 17.7.1
+- Updated Android SDK to 17.7.1
+- Fixed a bug that prevented custom event properties from being reported on iOS
+- Fixed contact subscription list updates (`EditContactSubscriptionLists`) on Android
+- Deprecated iOS `Trace` log level and add the replacement `Verbose` log level.
+
 ## Version 19.0.0 - Nov 21, 2023
 Major release that updates the Airship bindings and cross-platform libraries to target .NET 8.0. The Airship .NET SDK now requires .NET 8.0 (`net8.0-android` and `net8.0-ios`) as the minimum target framework, and iOS 14+ as the minimum deployment version with Xcode 15+.
 
-## Changes
+### Changes
 - Updated iOS SDK to 17.6.1
 - Resolved build issues in Windows Visual Studio. Linked Mac builds are now working as expected.
 
 ## Version 18.0.0 - Nov 10, 2023
 Major release that updates to Airship SDK 17.x. This release adds support for Stories, In-App experiences downstream of a sequence in Journeys, and improves SDK auth. The .NET SDK now requires .NET 7.0 (`net7.0-android` and `net7.0-ios`) as the minimum target framework, and iOS 14+ as the minimum deployment version with Xcode 14.3+.
 
-## Changes
+### Changes
 - Updated iOS SDK to 17.6.0
 - Updated Android SDK to 17.5.0
 - Added the ability to update Channel and Contact subscriptions to the common .NET library
@@ -19,7 +29,7 @@ Major release that updates to Airship SDK 17.x. This release adds support for St
 
 See the [Migration Guide](https://github.com/urbanairship/airship-dotnet/tree/main/MIGRATION.md) for further details.
 
-## Known Issues
+### Known Issues
 Build/run via a linked Mac from Visual Studio on Windows is not currently working as expected. This appears to be a known issue and is expected to be fixed in the upcoming .NET 8 release. In our testing, this issue impacts other SDKs that make use of XCFrameworks, and is not limited to Airship SDKs. We will continue monitoring the situation and update with any new workarounds or fixes that become available.
 
 Builds and runs performed directly on a Mac are not impacted by this issue.

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "urbanairship/ios-library" == 17.7.1
+github "urbanairship/ios-library" == 17.7.3

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "urbanairship/ios-library" == 17.6.1
+github "urbanairship/ios-library" == 17.7.1

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -5,12 +5,12 @@
 ### Requirements
 
 * Visual Studio for Mac ([stable](https://visualstudio.microsoft.com/vs/mac/) or [preview](https://visualstudio.microsoft.com/vs/mac/preview/))
-* A supported Xcode version (at the time of writing, VS 2022 supported Xcode 14.2)
+* A supported Xcode version (at the time of writing, VS 2022 recommends Xcode 15.1+)
 * OpenJDK 11
   * Using [Homebrew](https://brew.sh/): `brew install openjdk@11`
   * Or [SDKMAN!](https://sdkman.io/): `sdk install java 11.0.18-zulu`
 * Android SDK: API 31+ platform, emulator, build tools, command line tools, etc.
-* .NET6 SDK (install via VS)
+* .NET8 SDK (install via VS)
 * .NET Workloads (install via VS): maui, android, ios
 * Doxygen & Graphviz (`brew install doxygen graphviz`)
 * Carthage (`brew install carthage`)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,11 +5,11 @@
   <!-- Versions -->
   <PropertyGroup>
     <!-- Airship native SDK versions -->
-    <AirshipAndroidVersion>17.7.1</AirshipAndroidVersion>
-    <AirshipAndroidNugetVersion>17.7.1</AirshipAndroidNugetVersion>
+    <AirshipAndroidVersion>17.7.2</AirshipAndroidVersion>
+    <AirshipAndroidNugetVersion>17.7.2</AirshipAndroidNugetVersion>
 
-    <AirshipIosVersion>17.7.1</AirshipIosVersion>
-    <AirshipIosNugetVersion>17.7.1</AirshipIosNugetVersion>
+    <AirshipIosVersion>17.7.3</AirshipIosVersion>
+    <AirshipIosNugetVersion>17.7.3</AirshipIosNugetVersion>
 
     <!-- Airship.Net version -->
     <AirshipCrossPlatformVersion>19.1.0</AirshipCrossPlatformVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,15 +5,15 @@
   <!-- Versions -->
   <PropertyGroup>
     <!-- Airship native SDK versions -->
-    <AirshipAndroidVersion>17.5.0</AirshipAndroidVersion>
-    <AirshipAndroidNugetVersion>17.5.0.1</AirshipAndroidNugetVersion>
+    <AirshipAndroidVersion>17.7.1</AirshipAndroidVersion>
+    <AirshipAndroidNugetVersion>17.7.1</AirshipAndroidNugetVersion>
 
-    <AirshipIosVersion>17.6.1</AirshipIosVersion>
-    <AirshipIosNugetVersion>17.6.1</AirshipIosNugetVersion>
+    <AirshipIosVersion>17.7.1</AirshipIosVersion>
+    <AirshipIosNugetVersion>17.7.1</AirshipIosNugetVersion>
 
     <!-- Airship.Net version -->
-    <AirshipCrossPlatformVersion>19.0.0</AirshipCrossPlatformVersion>
-    <AirshipCrossPlatformNugetVersion>19.0.0</AirshipCrossPlatformNugetVersion>
+    <AirshipCrossPlatformVersion>19.1.0</AirshipCrossPlatformVersion>
+    <AirshipCrossPlatformNugetVersion>19.1.0</AirshipCrossPlatformNugetVersion>
   </PropertyGroup>
 
   <!-- Nuget packaging metadata -->

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,19 @@
 # Migration Guide
 
+## 18.x to 19.x
+
+### .NET Version
+
+This version of the plugin now requires .NET 8.0 (`net8.0-android` and `net8.0-ios`) as the min target framework.
+
+### Minimum iOS Version
+
+This version of the plugin requires iOS 14+ as the min deployment target and Xcode 15+.
+
+### iOS Log Levels
+
+The `TRACE` level has been renamed to `VERBOSE`, for consistency with other platforms/frameworks.
+
 ## 17.x to 18.x
 
 ### .NET Version
@@ -9,10 +23,6 @@ This version of the plugin now requires .NET 7.0 (`net7.0-android` and `net7.0-i
 ### Minimum iOS Version
 
 This version of the plugin now requires iOS 14+ as the min deployment target and Xcode 14.3+.
-
-### iOS Log Levels
-
-The `TRACE` level has been renamed to `VERBOSE`, for consistency with other platforms/frameworks.
 
 ### API Changes
 

--- a/MauiSample/MauiSample.csproj
+++ b/MauiSample/MauiSample.csproj
@@ -33,6 +33,8 @@
     <CodesignEntitlements>Platforms\iOS\Entitlements.plist</CodesignEntitlements>
     <MtouchLink>None</MtouchLink>
     <CreatePackage>false</CreatePackage>
+    <RuntimeIdentifier Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' != 'arm64'">iossimulator-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'arm64'">iossimulator-arm64</RuntimeIdentifier> 
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)'=='Release|net8.0-ios'">

--- a/MauiSample/Platforms/iOS/AppDelegate.cs
+++ b/MauiSample/Platforms/iOS/AppDelegate.cs
@@ -14,7 +14,7 @@ public class AppDelegate : MauiUIApplicationDelegate
     {
         // Set log level for debugging config loading (optional)
         // It will be set to the value in the loaded config upon takeOff
-        UAirship.LogLevel = UALogLevel.Trace;
+        UAirship.LogLevel = UALogLevel.Verbose;
 
         // Populate AirshipConfig.plist with your app's info from https://go.urbanairship.com
         // or set runtime properties here.

--- a/airship.properties
+++ b/airship.properties
@@ -1,6 +1,6 @@
 # Airship native SDK versions
-iosVersion = 17.7.1
-androidVersion = 17.7.1
+iosVersion = 17.7.3
+androidVersion = 17.7.2
 
 # Airship.Net cross-platform version
 crossPlatformVersion = 19.1.0

--- a/airship.properties
+++ b/airship.properties
@@ -1,9 +1,9 @@
 # Airship native SDK versions
-iosVersion = 17.6.1
-androidVersion = 17.5.0
+iosVersion = 17.7.1
+androidVersion = 17.7.1
 
 # Airship.Net cross-platform version
-crossPlatformVersion = 19.0.0
+crossPlatformVersion = 19.1.0
 
 # Filename of the iOS SDK zip file
 iosFrameworkZip = Airship-Xcode15.zip
@@ -12,7 +12,7 @@ iosFrameworkZip = Airship-Xcode15.zip
 # If > 0, the revision number will be added to the versions
 # defined above as a 4th segment (i.e., MAJOR.MINOR.PATCH.REVISION).
 # If = 0, NuGet packages will be versioned using standard 3-segment semver.
-androidRevision = 1
+androidRevision = 0
 iosRevision = 0
 crossPlatformRevision = 0
 

--- a/binderator/config.json
+++ b/binderator/config.json
@@ -17,72 +17,72 @@
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-adm",
-        "version": "17.7.1",
-        "nugetVersion": "17.7.1",
+        "version": "17.7.2",
+        "nugetVersion": "17.7.2",
         "nugetId": "Airship.Net.Android.Adm",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-automation",
-        "version": "17.7.1",
-        "nugetVersion": "17.7.1",
+        "version": "17.7.2",
+        "nugetVersion": "17.7.2",
         "nugetId": "Airship.Net.Android.Automation",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-core",
-        "version": "17.7.1",
-        "nugetVersion": "17.7.1",
+        "version": "17.7.2",
+        "nugetVersion": "17.7.2",
         "nugetId": "Airship.Net.Android.Core",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-fcm",
-        "version": "17.7.1",
-        "nugetVersion": "17.7.1",
+        "version": "17.7.2",
+        "nugetVersion": "17.7.2",
         "nugetId": "Airship.Net.Android.Fcm",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-feature-flag",
-        "version": "17.7.1",
-        "nugetVersion": "17.7.1",
+        "version": "17.7.2",
+        "nugetVersion": "17.7.2",
         "nugetId": "Airship.Net.Android.FeatureFlag",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-layout",
-        "version": "17.7.1",
-        "nugetVersion": "17.7.1",
+        "version": "17.7.2",
+        "nugetVersion": "17.7.2",
         "nugetId": "Airship.Net.Android.Layout",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-live-update",
-        "version": "17.7.1",
-        "nugetVersion": "17.7.1",
+        "version": "17.7.2",
+        "nugetVersion": "17.7.2",
         "nugetId": "Airship.Net.Android.LiveUpdate",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-message-center",
-        "version": "17.7.1",
-        "nugetVersion": "17.7.1",
+        "version": "17.7.2",
+        "nugetVersion": "17.7.2",
         "nugetId": "Airship.Net.Android.MessageCenter",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-preference-center",
-        "version": "17.7.1",
-        "nugetVersion": "17.7.1",
+        "version": "17.7.2",
+        "nugetVersion": "17.7.2",
         "nugetId": "Airship.Net.Android.PreferenceCenter",
         "dependencyOnly": false
       },

--- a/binderator/config.json
+++ b/binderator/config.json
@@ -17,72 +17,72 @@
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-adm",
-        "version": "17.5.0",
-        "nugetVersion": "17.5.0",
+        "version": "17.7.1",
+        "nugetVersion": "17.7.1",
         "nugetId": "Airship.Net.Android.Adm",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-automation",
-        "version": "17.5.0",
-        "nugetVersion": "17.5.0",
+        "version": "17.7.1",
+        "nugetVersion": "17.7.1",
         "nugetId": "Airship.Net.Android.Automation",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-core",
-        "version": "17.5.0",
-        "nugetVersion": "17.5.0",
+        "version": "17.7.1",
+        "nugetVersion": "17.7.1",
         "nugetId": "Airship.Net.Android.Core",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-fcm",
-        "version": "17.5.0",
-        "nugetVersion": "17.5.0",
+        "version": "17.7.1",
+        "nugetVersion": "17.7.1",
         "nugetId": "Airship.Net.Android.Fcm",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-feature-flag",
-        "version": "17.5.0",
-        "nugetVersion": "17.5.0",
+        "version": "17.7.1",
+        "nugetVersion": "17.7.1",
         "nugetId": "Airship.Net.Android.FeatureFlag",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-layout",
-        "version": "17.5.0",
-        "nugetVersion": "17.5.0",
+        "version": "17.7.1",
+        "nugetVersion": "17.7.1",
         "nugetId": "Airship.Net.Android.Layout",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-live-update",
-        "version": "17.5.0",
-        "nugetVersion": "17.5.0",
+        "version": "17.7.1",
+        "nugetVersion": "17.7.1",
         "nugetId": "Airship.Net.Android.LiveUpdate",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-message-center",
-        "version": "17.5.0",
-        "nugetVersion": "17.5.0",
+        "version": "17.7.1",
+        "nugetVersion": "17.7.1",
         "nugetId": "Airship.Net.Android.MessageCenter",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-preference-center",
-        "version": "17.5.0",
-        "nugetVersion": "17.5.0",
+        "version": "17.7.1",
+        "nugetVersion": "17.7.1",
         "nugetId": "Airship.Net.Android.PreferenceCenter",
         "dependencyOnly": false
       },

--- a/binderator/source/com.urbanairship.android/urbanairship-automation/Transforms/Metadata.xml
+++ b/binderator/source/com.urbanairship.android/urbanairship-automation/Transforms/Metadata.xml
@@ -12,6 +12,8 @@
   <attr path="/api/package[@name='com.urbanairship.iam.tags']" name="managedName">UrbanAirship.Iam.Tags</attr>
   <attr path="/api/package[@name='com.urbanairship.iam.view']" name="managedName">UrbanAirship.Iam.View</attr>
   
+  <attr path="/api/package[@name='com.urbanairship.automation.limits.storage']/class[@name='OccurrenceEntity.Comparator']/method[@name='compare']/parameter[@type='com.urbanairship.automation.limits.storage.OccurrenceEntity']" name="type">java.lang.Object</attr>
+
   <!-- Remove ActionScheduleEdits and ActionScheduleInfo data getters-->
   <remove-node path="/api/package[@name='com.urbanairship.automation']/interface[@name='ScheduleEdits']/method[@name='getData']" />
   <remove-node path="/api/package[@name='com.urbanairship.automation']/interface[@name='ScheduleInfo']/method[@name='getData']" />

--- a/src/Airship.Net/Platforms/iOS/Airship.cs
+++ b/src/Airship.Net/Platforms/iOS/Airship.cs
@@ -262,13 +262,13 @@ namespace AirshipDotNet
                 NSMutableDictionary<NSString, NSObject> propertyDictionary = new();
                 foreach (dynamic property in customEvent.PropertyList)
                 {
-                    if (string.IsNullOrEmpty(property.name))
+                    if (string.IsNullOrEmpty(property.Name))
                     {
                         continue;
                     }
 
-                    NSString key = (NSString)property.name;
-                    NSObject value = NSObject.FromObject(property.value);
+                    NSString key = (NSString)property.Name;
+                    NSObject value = NSObject.FromObject(property.Value);
 
                     if (property is CustomEvent.Property<string[]> stringArrayProperty)
                     {
@@ -283,8 +283,7 @@ namespace AirshipDotNet
                 }
                 if (propertyDictionary.Count > 0)
                 {
-                    //TODO: 
-                    //uaEvent.Properties = new NSDictionary<NSString, NSObject>(propertyDictionary.Keys, propertyDictionary.Values);
+                    uaEvent.Properties = new NSDictionary<NSString, NSObject>(propertyDictionary.Keys, propertyDictionary.Values);
                 }
             }
 
@@ -391,7 +390,7 @@ namespace AirshipDotNet
 
         public Channel.TagGroupsEditor EditChannelTagGroups()
         {
-            return new((List<Channel.TagGroupsEditor.TagOperation> payload) =>
+            return new(payload =>
             {
                 ChannelTagGroupHelper(payload, () =>
                 {
@@ -402,7 +401,7 @@ namespace AirshipDotNet
 
         public Channel.TagGroupsEditor EditContactTagGroups()
         {
-            return new((List<Channel.TagGroupsEditor.TagOperation> payload) =>
+            return new(payload =>
             {
                 ContactTagGroupHelper(payload);
             });
@@ -413,7 +412,7 @@ namespace AirshipDotNet
 
         public AttributeEditor EditChannelAttributes()
         {
-            return new((List<AttributeEditor.IAttributeOperation> operations) =>
+            return new(operations =>
             {
                 ApplyChannelAttributesOperations(operations);
             });
@@ -421,7 +420,7 @@ namespace AirshipDotNet
 
         public AttributeEditor EditContactAttributes()
         {
-            return new((List<AttributeEditor.IAttributeOperation> operations) =>
+            return new(operations =>
             {
                 ApplyContactAttributesOperations(operations);
             });
@@ -430,7 +429,7 @@ namespace AirshipDotNet
 
         public Channel.SubscriptionListEditor EditChannelSubscriptionLists()
         {
-            return new Channel.SubscriptionListEditor((List<Channel.SubscriptionListEditor.SubscriptionListOperation> payload) =>
+            return new Channel.SubscriptionListEditor(payload =>
             {
                 ApplyChannelSubscriptionListHelper(payload);
             });
@@ -438,7 +437,7 @@ namespace AirshipDotNet
 
         public Contact.SubscriptionListEditor EditContactSubscriptionLists()
         {
-            return new Contact.SubscriptionListEditor((List<Contact.SubscriptionListEditor.SubscriptionListOperation> payload) =>
+            return new Contact.SubscriptionListEditor(payload =>
             {
                 ApplyContactSubscriptionListHelper(payload);
             });
@@ -597,7 +596,7 @@ namespace AirshipDotNet
         {
             UAirship.Channel.EditSubscriptionLists(editor =>
             {
-                foreach (Channel.SubscriptionListEditor.SubscriptionListOperation operation in operations)
+                foreach (var operation in operations)
                 {
                     if (!Enum.IsDefined(typeof(Channel.SubscriptionListEditor.OperationType), operation.OperationType))
                     {
@@ -624,7 +623,7 @@ namespace AirshipDotNet
             UAirship.Contact.EditSubscriptionLists(editor =>
             {
 
-                foreach (Contact.SubscriptionListEditor.SubscriptionListOperation operation in operations)
+                foreach (var operation in operations)
                 {
                     if (!Enum.IsDefined(typeof(Contact.SubscriptionListEditor.OperationType), operation.OperationType))
                     {

--- a/src/AirshipBindings.iOS.Automation/AirshipBindings.iOS.Automation.csproj
+++ b/src/AirshipBindings.iOS.Automation/AirshipBindings.iOS.Automation.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Airship.Net.iOS.Automation</AssemblyName>
     <AssemblyTitle>Airship iOS SDK - Automation</AssemblyTitle>
     <Description>Automation support for Airship SDK</Description>
-    <TargetFramework>net7.0-ios</TargetFramework>
+    <TargetFramework>net8.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/src/AirshipBindings.iOS.Basement/AirshipBindings.iOS.Basement.csproj
+++ b/src/AirshipBindings.iOS.Basement/AirshipBindings.iOS.Basement.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Airship.Net.iOS.Basement</AssemblyName>
     <AssemblyTitle>Airship iOS SDK - Basement</AssemblyTitle>
     <Description>Basement module for Airship SDK</Description>
-    <TargetFramework>net7.0-ios</TargetFramework>
+    <TargetFramework>net8.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/src/AirshipBindings.iOS.Core/AirshipBindings.iOS.Core.csproj
+++ b/src/AirshipBindings.iOS.Core/AirshipBindings.iOS.Core.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>Airship.Net.iOS.Core</AssemblyName>
     <AssemblyTitle>Airship iOS SDK - Core</AssemblyTitle>
     <Description>Core of Airship SDK</Description>
-    <TargetFramework>net7.0-ios</TargetFramework>
+    <TargetFramework>net8.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/src/AirshipBindings.iOS.Core/StructsAndEnums.cs
+++ b/src/AirshipBindings.iOS.Core/StructsAndEnums.cs
@@ -2,6 +2,7 @@
  Copyright Airship and Contributors
 */
 
+using System;
 using ObjCRuntime;
 
 namespace UrbanAirship
@@ -48,7 +49,9 @@ namespace UrbanAirship
         Warn = 2,
         Info = 3,
         Debug = 4,
-        Trace = 5
+        [Obsolete("Use Verbose instead. Trace will be removed in a future release.")]
+        Trace = 5,
+        Verbose = 5
     }
 
     [Native]

--- a/src/AirshipBindings.iOS.MessageCenter/AirshipBindings.iOS.MessageCenter.csproj
+++ b/src/AirshipBindings.iOS.MessageCenter/AirshipBindings.iOS.MessageCenter.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Airship.Net.iOS.MessageCenter</AssemblyName>
     <AssemblyTitle>Airship iOS SDK - MessageCenter</AssemblyTitle>
     <Description>Message Center support for the Airship SDK</Description>
-    <TargetFramework>net7.0-ios</TargetFramework>
+    <TargetFramework>net8.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/src/AirshipBindings.iOS.NotificationContentExtension/AirshipBindings.iOS.NotificationContentExtension.csproj
+++ b/src/AirshipBindings.iOS.NotificationContentExtension/AirshipBindings.iOS.NotificationContentExtension.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>Airship.Net.iOS.NotificationContentExtension</AssemblyName>
     <AssemblyTitle>Airship iOS SDK - Notification Content Extension</AssemblyTitle>
     <Description>Notification content extension support for Airship SDK</Description>
-    <TargetFramework>net7.0-ios</TargetFramework>
+    <TargetFramework>net8.0-ios</TargetFramework>
     <DisableExtraReferences>true</DisableExtraReferences>
     <Nullable>enable</Nullable>
     <IsTrimmable>false</IsTrimmable>

--- a/src/AirshipBindings.iOS.NotificationServiceExtension/AirshipBindings.iOS.NotificationServiceExtension.csproj
+++ b/src/AirshipBindings.iOS.NotificationServiceExtension/AirshipBindings.iOS.NotificationServiceExtension.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>Airship.Net.iOS.NotificationServiceExtension</AssemblyName>
     <AssemblyTitle>Airship iOS SDK - Notification Service Extension</AssemblyTitle>
     <Description>Notification service extension support for Airship SDK</Description>
-    <TargetFramework>net7.0-ios</TargetFramework>
+    <TargetFramework>net8.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/src/AirshipBindings.iOS.PreferenceCenter/AirshipBindings.iOS.PreferenceCenter.csproj
+++ b/src/AirshipBindings.iOS.PreferenceCenter/AirshipBindings.iOS.PreferenceCenter.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>Airship.Net.iOS.PreferenceCenter</AssemblyName>
     <AssemblyTitle>Airship iOS SDK - Preference Center</AssemblyTitle>
     <Description>Preference Center support for Airship SDK</Description>
-    <TargetFramework>net7.0-ios</TargetFramework>
+    <TargetFramework>net8.0-ios</TargetFramework>
     <DisableExtraReferences>true</DisableExtraReferences>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>

--- a/src/SharedAssemblyInfo.Common.cs
+++ b/src/SharedAssemblyInfo.Common.cs
@@ -6,4 +6,4 @@ using UrbanAirship.Attributes;
 // Change them to the values specific to your project.
 
 // Cross-platform version of the plugin
-[assembly: UACrossPlatformVersion ("19.0.0")]
+[assembly: UACrossPlatformVersion ("19.1.0")]

--- a/src/SharedAssemblyInfo.CrossPlatform.cs
+++ b/src/SharedAssemblyInfo.CrossPlatform.cs
@@ -12,5 +12,5 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("19.0.0")]
+[assembly: AssemblyVersion ("19.1.0")]
 

--- a/src/SharedAssemblyInfo.iOS.cs
+++ b/src/SharedAssemblyInfo.iOS.cs
@@ -17,4 +17,4 @@ using System.Reflection;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("19.0.0")]
+[assembly: AssemblyVersion ("19.1.0")]


### PR DESCRIPTION
### What do these changes do?

* Uncomments the line that adds custom event properties to the native custom event object
* Deprecates UALogLevel.Trace and adds UALogLevel.Verbose (with the same value, so they'll do the same thing, but Trace will show a warning in the IDE)
* Fixes Android `EditContactSubscriptionLists` to actually do what it says
* Minor tidy ups in `Airship.Net` for iOS and Android
* Adds `RuntimeIdentifier`s to the sample csproj, to better support building to simulators
* Bumped iOS bindings to target `.net8.0-ios`
* Bumped Android and iOS SDKs to `17.7.1`
* Prep for release `19.1.0`

### Why are these changes necessary?

* Customer reported a custom event property bug on Xamarin that we also have in dotnet
* Fixed other things that needed fixing

### How did you verify these changes?

Manually in sample app, verifying against the go dashboard and RTDS

