### PR TITLE
Release 19.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Airship DotNet Changelog
 
+## Version 19.3.0 - Apr 8, 2024
+Minor release that updates the Airship SDK to iOS 17.10.0 and Android 17.7.4,
+
+### Changes
+- Updated iOS SDK to 17.10.0
+- Updated Android SDK to 17.7.4
+- iOS: Fixed issue with frequency checks being checked before the message is ready to display
+- Android: Fixed channel ID creation delay after enabling a feature when none was enabled
+- Android: Fixed a potential NPE when reading from intent extras on API 33
+
 ## Version 19.2.0 - Mar 15, 2024
 Minor release that updates the Airship SDK to iOS 17.9.0 and Android 17.7.3, and expands plist theming options available for Message Center.
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "urbanairship/ios-library" == 17.9.0
+github "urbanairship/ios-library" == 17.10.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,15 +5,15 @@
   <!-- Versions -->
   <PropertyGroup>
     <!-- Airship native SDK versions -->
-    <AirshipAndroidVersion>17.7.3</AirshipAndroidVersion>
-    <AirshipAndroidNugetVersion>17.7.3</AirshipAndroidNugetVersion>
+    <AirshipAndroidVersion>17.7.4</AirshipAndroidVersion>
+    <AirshipAndroidNugetVersion>17.7.4</AirshipAndroidNugetVersion>
 
-    <AirshipIosVersion>17.9.0</AirshipIosVersion>
-    <AirshipIosNugetVersion>17.9.0</AirshipIosNugetVersion>
+    <AirshipIosVersion>17.10.0</AirshipIosVersion>
+    <AirshipIosNugetVersion>17.10.0</AirshipIosNugetVersion>
 
     <!-- Airship.Net version -->
-    <AirshipCrossPlatformVersion>19.2.0</AirshipCrossPlatformVersion>
-    <AirshipCrossPlatformNugetVersion>19.2.0</AirshipCrossPlatformNugetVersion>
+    <AirshipCrossPlatformVersion>19.3.0</AirshipCrossPlatformVersion>
+    <AirshipCrossPlatformNugetVersion>19.3.0</AirshipCrossPlatformNugetVersion>
   </PropertyGroup>
 
   <!-- Nuget packaging metadata -->

--- a/MauiSample/Platforms/iOS/MessageCenterTheme.plist
+++ b/MauiSample/Platforms/iOS/MessageCenterTheme.plist
@@ -77,6 +77,6 @@
 	<key>backButtonColorDark</key>
 	<string>#DDDDDD</string>
 	<key>navigationBarTitle</key>
-	<string>Test Navigation Bar Title</string>
+	<string>Nav Bar Title</string>
 </dict>
 </plist>

--- a/airship.properties
+++ b/airship.properties
@@ -1,12 +1,12 @@
 # Airship native SDK versions
-iosVersion = 17.9.0
-androidVersion = 17.7.3
+iosVersion = 17.10.0
+androidVersion = 17.7.4
 
 # Airship.Net cross-platform version
-crossPlatformVersion = 19.2.0
+crossPlatformVersion = 19.3.0
 
 # Filename of the iOS SDK zip file
-iosFrameworkZip = Airship-Xcode15.zip
+iosFrameworkZip = Airship.zip
 
 # NuGet package revision numbers
 # If > 0, the revision number will be added to the versions

--- a/binderator/config.json
+++ b/binderator/config.json
@@ -17,72 +17,72 @@
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-adm",
-        "version": "17.7.3",
-        "nugetVersion": "17.7.3",
+        "version": "17.7.4",
+        "nugetVersion": "17.7.4",
         "nugetId": "Airship.Net.Android.Adm",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-automation",
-        "version": "17.7.3",
-        "nugetVersion": "17.7.3",
+        "version": "17.7.4",
+        "nugetVersion": "17.7.4",
         "nugetId": "Airship.Net.Android.Automation",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-core",
-        "version": "17.7.3",
-        "nugetVersion": "17.7.3",
+        "version": "17.7.4",
+        "nugetVersion": "17.7.4",
         "nugetId": "Airship.Net.Android.Core",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-fcm",
-        "version": "17.7.3",
-        "nugetVersion": "17.7.3",
+        "version": "17.7.4",
+        "nugetVersion": "17.7.4",
         "nugetId": "Airship.Net.Android.Fcm",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-feature-flag",
-        "version": "17.7.3",
-        "nugetVersion": "17.7.3",
+        "version": "17.7.4",
+        "nugetVersion": "17.7.4",
         "nugetId": "Airship.Net.Android.FeatureFlag",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-layout",
-        "version": "17.7.3",
-        "nugetVersion": "17.7.3",
+        "version": "17.7.4",
+        "nugetVersion": "17.7.4",
         "nugetId": "Airship.Net.Android.Layout",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-live-update",
-        "version": "17.7.3",
-        "nugetVersion": "17.7.3",
+        "version": "17.7.4",
+        "nugetVersion": "17.7.4",
         "nugetId": "Airship.Net.Android.LiveUpdate",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-message-center",
-        "version": "17.7.3",
-        "nugetVersion": "17.7.3",
+        "version": "17.7.4",
+        "nugetVersion": "17.7.4",
         "nugetId": "Airship.Net.Android.MessageCenter",
         "dependencyOnly": false
       },
       {
         "groupId": "com.urbanairship.android",
         "artifactId": "urbanairship-preference-center",
-        "version": "17.7.3",
-        "nugetVersion": "17.7.3",
+        "version": "17.7.4",
+        "nugetVersion": "17.7.4",
         "nugetId": "Airship.Net.Android.PreferenceCenter",
         "dependencyOnly": false
       },

--- a/src/SharedAssemblyInfo.Common.cs
+++ b/src/SharedAssemblyInfo.Common.cs
@@ -6,4 +6,4 @@ using UrbanAirship.Attributes;
 // Change them to the values specific to your project.
 
 // Cross-platform version of the plugin
-[assembly: UACrossPlatformVersion ("19.2.0")]
+[assembly: UACrossPlatformVersion ("19.3.0")]

--- a/src/SharedAssemblyInfo.CrossPlatform.cs
+++ b/src/SharedAssemblyInfo.CrossPlatform.cs
@@ -12,5 +12,5 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("19.2.0")]
+[assembly: AssemblyVersion ("19.3.0")]
 

--- a/src/SharedAssemblyInfo.iOS.cs
+++ b/src/SharedAssemblyInfo.iOS.cs
@@ -17,4 +17,4 @@ using System.Reflection;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("19.2.0")]
+[assembly: AssemblyVersion ("19.3.0")]


### PR DESCRIPTION
## Version 19.3.0 - Apr 8, 2024
Minor release that updates the Airship SDK to iOS 17.10.0 and Android 17.7.4,

### Changes
- Updated iOS SDK to 17.10.0
- Updated Android SDK to 17.7.4
- iOS: Fixed issue with frequency checks being checked before the message is ready to display
- Android: Fixed channel ID creation delay after enabling a feature when none was enabled
- Android: Fixed a potential NPE when reading from intent extras on API 33

