### PR TITLE
[MOBILE-4832] Remove MAUI dependency from Airship.Net package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,16 +13,16 @@ jobs:
   ci:
     runs-on: macOS-13
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '11'
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
 
@@ -73,7 +73,10 @@ jobs:
       - name: Build
         run: ./gradlew build pack buildSample
 
-      - uses: actions/upload-artifact@v2
+      - name: Upload build dir artifact
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build
+          retention-days: 7 # For debugging, so we don't need to keep them for very long
+          compression-level: 0 # Nupkgs are just .zip files, so no need to compress them

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       contents: write
     runs-on: macOS-13
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Get Version
         id: get_version
@@ -56,13 +56,13 @@ jobs:
       #   uses: google-github-actions/setup-gcloud@v1
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '11'
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
 
@@ -83,7 +83,7 @@ jobs:
         
       - name: Create Github Release
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.get_version.outputs.VERSION }}
           release_name: ${{ steps.get_version.outputs.VERSION }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Airship DotNet Changelog
 
+## Version 19.4.1 - Dec 6, 2024
+Minor release that updates the Airship.Net package to no longer depend on MAUI.
+
+### Changes
+- Removed unnecessary MAUI dependency from Airship.Net
+
 ## Version 19.4.0 - July 29, 2024
 Minor release that updates the Airship SDK to iOS 17.10.1 and Android 17.8.1.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Airship DotNet Changelog
 
-## Version 19.4.1 - Dec 6, 2024
-Minor release that updates the Airship.Net package to no longer depend on MAUI.
+## Version 19.4.1 - Dec 12, 2024
+Minor release that updates the Airship.Net package to no longer depend on MAUI and adds methods to fetch channel and contact subscription lists to the cross-platform library.
 
 ### Changes
 - Removed unnecessary MAUI dependency from Airship.Net
+- Added `FetchChannelSubscriptionLists` and `FetchContactSubscriptionLists` methods to Airship.Net
 
 ## Version 19.4.0 - July 29, 2024
 Minor release that updates the Airship SDK to iOS 17.10.1 and Android 17.8.1.

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -4,14 +4,14 @@
 
 ### Requirements
 
-* Visual Studio for Mac ([stable](https://visualstudio.microsoft.com/vs/mac/) or [preview](https://visualstudio.microsoft.com/vs/mac/preview/))
-* A supported Xcode version (at the time of writing, VS 2022 recommends Xcode 15.1+)
-* OpenJDK 11
-  * Using [Homebrew](https://brew.sh/): `brew install openjdk@11`
-  * Or [SDKMAN!](https://sdkman.io/): `sdk install java 11.0.18-zulu`
-* Android SDK: API 31+ platform, emulator, build tools, command line tools, etc.
-* .NET8 SDK (install via VS)
-* .NET Workloads (install via VS): maui, android, ios
+* VSCode and the [.NET MAUI](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-maui) plugin, or another .NET IDE such as Rider
+* A [supported](https://github.com/dotnet/maui/wiki/Release-Versions) Xcode version
+* OpenJDK 17
+  * Using [Homebrew](https://brew.sh/): `brew install openjdk@17`
+  * Or [SDKMAN!](https://sdkman.io/): `sdk install java 17.0.10-zulu`
+* Android SDK: API 34+ platform, emulator, build tools, command line tools, etc.
+* .NET8 SDK (installed via VSCode extension)
+* .NET Workloads (install via dotnet cli): maui, android, ios
 * Doxygen & Graphviz (`brew install doxygen graphviz`)
 * Carthage (`brew install carthage`)
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,14 +6,14 @@
   <PropertyGroup>
     <!-- Airship native SDK versions -->
     <AirshipAndroidVersion>17.8.1</AirshipAndroidVersion>
-    <AirshipAndroidNugetVersion>17.8.1</AirshipAndroidNugetVersion>
+    <AirshipAndroidNugetVersion>17.8.1.1</AirshipAndroidNugetVersion>
 
     <AirshipIosVersion>17.10.1</AirshipIosVersion>
-    <AirshipIosNugetVersion>17.10.1</AirshipIosNugetVersion>
+    <AirshipIosNugetVersion>17.10.1.1</AirshipIosNugetVersion>
 
     <!-- Airship.Net version -->
-    <AirshipCrossPlatformVersion>19.4.0</AirshipCrossPlatformVersion>
-    <AirshipCrossPlatformNugetVersion>19.4.0</AirshipCrossPlatformNugetVersion>
+    <AirshipCrossPlatformVersion>19.4.1</AirshipCrossPlatformVersion>
+    <AirshipCrossPlatformNugetVersion>19.4.1</AirshipCrossPlatformNugetVersion>
   </PropertyGroup>
 
   <!-- Nuget packaging metadata -->

--- a/airship.properties
+++ b/airship.properties
@@ -3,7 +3,7 @@ iosVersion = 17.10.1
 androidVersion = 17.8.1
 
 # Airship.Net cross-platform version
-crossPlatformVersion = 19.4.0
+crossPlatformVersion = 19.4.1
 
 # Filename of the iOS SDK zip file
 iosFrameworkZip = Airship-Xcode15.zip
@@ -12,7 +12,7 @@ iosFrameworkZip = Airship-Xcode15.zip
 # If > 0, the revision number will be added to the versions
 # defined above as a 4th segment (i.e., MAJOR.MINOR.PATCH.REVISION).
 # If = 0, NuGet packages will be versioned using standard 3-segment semver.
-androidRevision = 0
-iosRevision = 0
+androidRevision = 1
+iosRevision = 1
 crossPlatformRevision = 0
 

--- a/binderator/source/AndroidProject.cshtml
+++ b/binderator/source/AndroidProject.cshtml
@@ -79,8 +79,9 @@
     Performance hit for builds
     - BG8A04: <attr path="XPath" /> matched no nodes.
     - BG8A00: <remove-node path="XPath" /> matched no nodes.
+    - XAOBS001: Restricted APIs (we're only using our own)
     -->
-    <NoWarn>08A04;BG8A00;CS0109;CS0108;CS0114</NoWarn>
+    <NoWarn>08A04;BG8A00;CS0109;CS0108;CS0114;XAOBS001</NoWarn>
     <!--
     Harmful
     - BG8401: Skipping managed_type, due to a duplicate field, method or nested type name. (Nested type) (Java type: java_type)

--- a/src/Airship.Net/Airship.Net.csproj
+++ b/src/Airship.Net/Airship.Net.csproj
@@ -32,6 +32,11 @@
 	  <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
 	</PropertyGroup>
 
+	<ItemGroup>
+		<Compile Remove="Platforms/Android/**" Condition="'$(TargetFramework)' != 'net8.0-android'" />
+		<Compile Remove="Platforms/iOS/**" Condition="'$(TargetFramework)' != 'net8.0-ios'" />
+	</ItemGroup>
+
 	<!-- Dependencies -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
 		<ProjectReference Include="..\..\binderator\generated\Airship.Net.Android.Automation\Airship.Net.Android.Automation.csproj" />

--- a/src/Airship.Net/Airship.Net.csproj
+++ b/src/Airship.Net/Airship.Net.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net8.0-android;net8.0-ios</TargetFrameworks>
-		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>latest</LangVersion>
@@ -34,17 +33,13 @@
 	</PropertyGroup>
 
 	<!-- Dependencies -->
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.6" />
-	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
 		<ProjectReference Include="..\..\binderator\generated\Airship.Net.Android.Automation\Airship.Net.Android.Automation.csproj" />
 		<ProjectReference Include="..\..\binderator\generated\Airship.Net.Android.Core\Airship.Net.Android.Core.csproj" />
 		<ProjectReference Include="..\..\binderator\generated\Airship.Net.Android.Layout\Airship.Net.Android.Layout.csproj" />
 		<ProjectReference Include="..\..\binderator\generated\Airship.Net.Android.MessageCenter\Airship.Net.Android.MessageCenter.csproj" />
 	</ItemGroup>
-	 <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
 		<ProjectReference Include="..\AirshipBindings.iOS.Automation\AirshipBindings.iOS.Automation.csproj" />
 		<ProjectReference Include="..\AirshipBindings.iOS.Core\AirshipBindings.iOS.Core.csproj" />
 		<ProjectReference Include="..\AirshipBindings.iOS.Basement\AirshipBindings.iOS.Basement.csproj" />

--- a/src/SharedAssemblyInfo.Common.cs
+++ b/src/SharedAssemblyInfo.Common.cs
@@ -6,4 +6,4 @@ using UrbanAirship.Attributes;
 // Change them to the values specific to your project.
 
 // Cross-platform version of the plugin
-[assembly: UACrossPlatformVersion ("19.4.0")]
+[assembly: UACrossPlatformVersion ("19.4.1")]

--- a/src/SharedAssemblyInfo.CrossPlatform.cs
+++ b/src/SharedAssemblyInfo.CrossPlatform.cs
@@ -12,5 +12,5 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("19.4.0")]
+[assembly: AssemblyVersion ("19.4.1")]
 

--- a/src/SharedAssemblyInfo.iOS.cs
+++ b/src/SharedAssemblyInfo.iOS.cs
@@ -17,4 +17,4 @@ using System.Reflection;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("19.4.0")]
+[assembly: AssemblyVersion ("19.4.1")]


### PR DESCRIPTION
### What do these changes do?

Removes MAUI as a dependency of Airship.Net, since we aren't actually exposing any MAUI UI controls from that package.

Also updated the dev readme with VSCode setup instructions, now that VS for Mac is retired.

### Why are these changes necessary?

Makes our cross-platform Airship.Net package usable in 3rd-party .NET frameworks (i.e. not MAUI)

### How did you verify these changes?

Ran the sample app
