### PR TITLE
Cancel link-activated navigations in MessageView webview

### DIFF
--- a/MauiSample/App.xaml.cs
+++ b/MauiSample/App.xaml.cs
@@ -43,6 +43,14 @@ public partial class App : Application
                         ((AppShell)App.Current.MainPage).SwitchtoTab(Tabs.settingsTab);
                         return;
 
+                    case "product":
+                        MainThread.BeginInvokeOnMainThread(async () =>
+                        {
+                            var currentPage = Shell.Current.CurrentPage;
+                            await currentPage.Navigation.PushAsync(new ProductPage());
+                        });
+                        return;
+
                     default:
                         break;
                 }

--- a/MauiSample/ProductPage.xaml
+++ b/MauiSample/ProductPage.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MauiSample.ProductPage"
+             Title="Product Page">
+
+    <VerticalStackLayout Padding="20" Spacing="16">
+        <Label Text="Product Page" FontSize="28" FontAttributes="Bold" />
+        <Label Text="This page was opened via deep link from a Message Center CTA." />
+        <Label Text="Press the back button to return to the message." TextColor="Gray" />
+    </VerticalStackLayout>
+
+</ContentPage>

--- a/MauiSample/ProductPage.xaml.cs
+++ b/MauiSample/ProductPage.xaml.cs
@@ -1,0 +1,9 @@
+namespace MauiSample;
+
+public partial class ProductPage : ContentPage
+{
+    public ProductPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Airship.Net.MessageCenter/Controls/Platforms/iOS/MessageViewHandler.cs
+++ b/src/Airship.Net.MessageCenter/Controls/Platforms/iOS/MessageViewHandler.cs
@@ -15,6 +15,7 @@ namespace AirshipDotNet.MessageCenter.Controls
         private WKWebView _webView = null!;
         private NSObject? _webViewObserver;
         private UAMessageCenterNativeBridge _nativeBridge = null!;
+        private MessageWebViewDelegate _webViewDelegate = null!;
 
         public MessageViewHandler() : base(PropertyMapper, CommandMapper)
         {
@@ -38,7 +39,8 @@ namespace AirshipDotNet.MessageCenter.Controls
             _webView.AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
 
             _nativeBridge = new UAMessageCenterNativeBridge();
-            _nativeBridge.ForwardNavigationDelegate = new MessageWebViewDelegate(this);
+            _webViewDelegate = new MessageWebViewDelegate(this);
+            _nativeBridge.ForwardNavigationDelegate = _webViewDelegate;
             _webView.WeakNavigationDelegate = _nativeBridge.NavigationDelegate;
 
             _containerView.AddSubview(_webView);
@@ -66,6 +68,7 @@ namespace AirshipDotNet.MessageCenter.Controls
 
             _nativeBridge?.Dispose();
             _nativeBridge = null!;
+            _webViewDelegate = null!;
 
             _webView?.RemoveFromSuperview();
             _webView?.Dispose();
@@ -174,15 +177,19 @@ namespace AirshipDotNet.MessageCenter.Controls
             public void DecidePolicy(WKWebView webView, WKNavigationAction navigationAction, Action<WKNavigationActionPolicy> decisionHandler)
             {
                 var url = navigationAction.Request.Url;
-                if (url != null && url.Scheme != "http" && url.Scheme != "https")
-                {
-                    decisionHandler(WKNavigationActionPolicy.Cancel);
-                    UAirship.ProcessDeepLink(url, (_) => { });
-                }
-                else
+
+                // Allow programmatic loads (the initial message body load).
+                // Cancel user-tapped link activations and route them through
+                // ProcessDeepLink so they open externally rather than navigating
+                // the WKWebView away from the message content.
+                if (url == null || navigationAction.NavigationType != WKNavigationType.LinkActivated)
                 {
                     decisionHandler(WKNavigationActionPolicy.Allow);
+                    return;
                 }
+
+                decisionHandler(WKNavigationActionPolicy.Cancel);
+                UAirship.ProcessDeepLink(url, (_) => { });
             }
         }
     }


### PR DESCRIPTION
## Summary

- `MessageWebViewDelegate.DecidePolicy` now cancels `LinkActivated` navigations (user-tapped links) and routes them through `UAirship.ProcessDeepLink` instead of allowing the WKWebView to navigate away from the message body
- Programmatic loads (the initial message body `LoadRequest`) are unaffected — they continue to pass through as before
- Adds `ProductPage` and a `product` deep link handler to MauiSample to demonstrate the push-then-back navigation pattern with a custom URL scheme CTA
