### PR TITLE
Extract docs publishing into reusable workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,107 @@
+name: Publish Docs
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+    secrets:
+      GCP_SA_KEY:
+        required: true
+      CARTHAGE_GITHUB_TOKEN:
+        required: false
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to publish docs for (e.g. 12.0.0)'
+        required: true
+        type: string
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+env:
+  DEVELOPER_DIR: /Applications/Xcode_16.0.app/Contents/Developer
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: 1
+  HOMEBREW_NO_INSTALL_CLEANUP: 1
+
+jobs:
+  release-docs:
+    runs-on: macOS-15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+          dotnet-version: |
+            10.0.x
+
+      - name: Restore workloads
+        run: |
+          dotnet workload install android ios maui-android maui-ios maui-maccatalyst
+
+      - name: Download iOS SDK xcframeworks
+        env:
+          GH_TOKEN: ${{ secrets.CARTHAGE_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          IOS_VERSION=$(grep '^iosVersion' airship.properties | cut -d'=' -f2 | tr -d ' ')
+          gh release download "$IOS_VERSION" \
+            --repo urbanairship/ios-library \
+            --pattern "Airship.dotnet.xcframeworks.zip" \
+            --output Airship.dotnet.xcframeworks.zip
+          mkdir -p Carthage/Build
+          unzip -q Airship.dotnet.xcframeworks.zip
+          mv xcframeworks/*.xcframework Carthage/Build/
+          rm -rf xcframeworks Airship.dotnet.xcframeworks.zip
+
+      - name: Build AirshipWrapper
+        run: |
+          cd AirshipWrapper && ./build-wrapper.sh && cd ..
+          if [ ! -d "AirshipWrapper/lib/AirshipWrapper.xcframework" ]; then
+            echo "ERROR: AirshipWrapper.xcframework not found after build!"
+            exit 1
+          fi
+          mkdir -p src/AirshipBindings.iOS.ObjectiveC/lib
+          cp -R AirshipWrapper/lib/AirshipWrapper.xcframework src/AirshipBindings.iOS.ObjectiveC/lib/
+
+      - name: Install doc dependencies
+        run: |
+          brew install doxygen
+          brew install graphviz
+
+      - name: Build & Package docs
+        run: ./gradlew packageDocs
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/build/html
+
+  deploy-docs:
+    needs: release-docs
+    runs-on: ubuntu-latest
+    continue-on-error: true # Remove when migration to GH Pages is complete
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,19 +42,6 @@ jobs:
             echo ${delimiter}
           } >> $GITHUB_OUTPUT
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-
-      # - name: Setup GCP Auth
-      #   uses: google-github-actions/auth@v1
-      #   with:
-      #     credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      # # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
-      # - name: Set up Google Cloud SDK
-      #   uses: google-github-actions/setup-gcloud@v1
-
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -127,16 +114,10 @@ jobs:
           mkdir -p src/AirshipBindings.iOS.ObjectiveC/lib
           cp -R AirshipWrapper/lib/AirshipWrapper.xcframework src/AirshipBindings.iOS.ObjectiveC/lib/
 
-      # - name: Install doc dependencies
-      #   run: |
-      #     brew install doxygen
-      #     brew install graphviz
-
       - name: Build and Publish Nugets
         env:
           NUGET_PRODUCTION_API_KEY: ${{ secrets.NUGET_PRODUCTION_API_KEY }}
         run: ./gradlew build pack publishToProduction --warning-mode=summary --no-parallel
-        #run: ./gradlew build pack packageDocs
         
       - name: Create Github Release
         id: create_release
@@ -148,8 +129,15 @@ jobs:
           draft: false
           prerelease: false
 
-      # - name: Upload Docs
-      #   run: |
-      #     VERSION=${{ steps.get_version.outputs.VERSION }}
-      #     gsutil cp docs/build/$VERSION.tar.gz gs://ua-web-ci-prod-docs-transfer/libraries/maui/$VERSION.tar.gz
+
+  publish-docs:
+    needs: release
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/publish-docs.yml
+    with:
+      version: ${{ github.ref_name }}
+    secrets: inherit
 


### PR DESCRIPTION
## Summary

- Extracts all doc-building and doc-deploying steps from the `release` job into a new reusable workflow at `.github/workflows/publish-docs.yml`
- Adds a `publish-docs` caller job to the release workflow that runs after `release` completes
- Supports two triggers on the shared workflow:
  - `workflow_call` — invoked automatically on tag push via the release workflow
  - `workflow_dispatch` — allows manually republishing docs for any existing tag from the Actions UI

## Details

The shared workflow runs on `macOS-15` and includes the full build setup (JDK, .NET, workloads, iOS xcframeworks, AirshipWrapper) because `packageDocs` depends on `build`, which is required for the binderator to generate the Android binding `.cs` files that Doxygen documents.

## One-time repo setup required

For the GitHub Pages deploy step to succeed, a repo admin needs to set **Settings → Pages → Build and deployment source → GitHub Actions**. Until then, the `deploy-docs` job will fail with a non-blocking yellow warning (`continue-on-error: true`).

## Test plan

- [ ] On next tag push, verify `release` job completes (NuGet published, GitHub Release created), then `publish-docs` → `release-docs` completes (GCS upload succeeds, Pages artifact uploaded), and `deploy-docs` either succeeds or shows the expected `continue-on-error` warning
- [ ] Trigger `workflow_dispatch` manually from the Actions tab with an existing version tag to verify the standalone republish path works

🤖 Generated with [Claude Code](https://claude.com/claude-code)