### PR TITLE
Wire remaining event types for Flutter/RN parity

### DIFF
--- a/MauiSample/App.xaml.cs
+++ b/MauiSample/App.xaml.cs
@@ -15,9 +15,7 @@ public partial class App : Application
         // Register deep link event handler
         AirshipDotNet.Airship.Instance.OnDeepLinkReceived += OnDeepLinkReceived;
 
-        AirshipDotNet.Airship.Instance.OnMessageCenterDisplay += OnMessageCenterDisplay;
-
-        AirshipDotNet.Airship.MessageCenter.OnMessagesUpdated += OnMessagesUpdated;
+        AirshipDotNet.Airship.Instance.OnMessageCenterUpdated += OnMessageCenterUpdated;
     }
 
     private void OnDeepLinkReceived(object sender, DeepLinkEventArgs e)
@@ -52,13 +50,7 @@ public partial class App : Application
         Console.WriteLine("App does not know how to handle deepLink" + uri);
     }
 
-    private void OnMessageCenterDisplay(object sender, MessageCenterEventArgs e)
-    {
-        string messageId = e.MessageId;
-        Console.WriteLine("Ready to display message center message" + e.MessageId);
-    }
-
-    private async void OnMessagesUpdated(object sender, EventArgs e)
+    private async void OnMessageCenterUpdated(object sender, EventArgs e)
     {
         // Fetch counts when inbox is updated (e.g., to update a badge)
         var unreadCount = await AirshipDotNet.Airship.MessageCenter.GetUnreadCount();

--- a/src/Airship.Net/EventArgs.cs
+++ b/src/Airship.Net/EventArgs.cs
@@ -1,6 +1,7 @@
 /* Copyright Airship and Contributors */
 
 using System;
+using System.Collections.Generic;
 
 namespace AirshipDotNet
 {
@@ -44,6 +45,116 @@ namespace AirshipDotNet
         }
     }
     
+    /// <summary>
+    /// Event args for push notifications received.
+    /// </summary>
+    public class PushReceivedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the raw notification payload (APNs userInfo on iOS, push extras on Android).
+        /// </summary>
+        public IDictionary<string, object?> Payload { get; }
+
+        /// <summary>
+        /// Gets the alert text, or null if not present.
+        /// </summary>
+        public string? Alert { get; }
+
+        /// <summary>
+        /// Gets the notification title, or null if not present.
+        /// </summary>
+        public string? Title { get; }
+
+        /// <summary>
+        /// True when this was a silent/background push that did not post a notification.
+        /// </summary>
+        public bool IsBackground { get; }
+
+        public PushReceivedEventArgs(IDictionary<string, object?> payload, string? alert, string? title, bool isBackground)
+        {
+            Payload = payload;
+            Alert = alert;
+            Title = title;
+            IsBackground = isBackground;
+        }
+    }
+
+    /// <summary>
+    /// Event args for the user interacting with a notification.
+    /// </summary>
+    public class NotificationResponseEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the underlying push payload.
+        /// </summary>
+        public PushReceivedEventArgs Push { get; }
+
+        /// <summary>
+        /// Gets the action identifier the user tapped, or null for the default tap.
+        /// </summary>
+        public string? ActionId { get; }
+
+        /// <summary>
+        /// True if the action ran in the foreground.
+        /// </summary>
+        public bool IsForeground { get; }
+
+        public NotificationResponseEventArgs(PushReceivedEventArgs push, string? actionId, bool isForeground)
+        {
+            Push = push;
+            ActionId = actionId;
+            IsForeground = isForeground;
+        }
+    }
+
+    /// <summary>
+    /// Event args for push token registration.
+    /// </summary>
+    public class PushTokenReceivedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the push token (APNs device token hex on iOS, FCM registration token on Android).
+        /// </summary>
+        public string Token { get; }
+
+        public PushTokenReceivedEventArgs(string token)
+        {
+            Token = token;
+        }
+    }
+
+    /// <summary>
+    /// Event args for preference center open requests.
+    /// </summary>
+    public class PreferenceCenterEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the preference center identifier the user requested.
+        /// </summary>
+        public string PreferenceCenterId { get; }
+
+        public PreferenceCenterEventArgs(string preferenceCenterId)
+        {
+            PreferenceCenterId = preferenceCenterId;
+        }
+    }
+
+    /// <summary>
+    /// Event args for iOS authorized notification settings changes.
+    /// </summary>
+    public class IOSAuthorizedNotificationSettingsEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the raw authorized settings bitmask reported by iOS.
+        /// </summary>
+        public ulong AuthorizedSettings { get; }
+
+        public IOSAuthorizedNotificationSettingsEventArgs(ulong authorizedSettings)
+        {
+            AuthorizedSettings = authorizedSettings;
+        }
+    }
+
     /// <summary>
     /// Event args for deep link events.
     /// </summary>

--- a/src/Airship.Net/Events/AirshipEventStream.cs
+++ b/src/Airship.Net/Events/AirshipEventStream.cs
@@ -26,8 +26,6 @@ namespace AirshipDotNet.Events
         /// </summary>
         public static readonly Dictionary<AirshipEventType, string> EventNameMap = new()
         {
-            { AirshipEventType.BackgroundNotificationResponse, "com.airship.dotnet/event/notification_response" },
-            { AirshipEventType.ForegroundNotificationResponse, "com.airship.dotnet/event/notification_response" },
             { AirshipEventType.NotificationResponse, "com.airship.dotnet/event/notification_response" },
             { AirshipEventType.ChannelCreated, "com.airship.dotnet/event/channel_created" },
             { AirshipEventType.DeepLinkReceived, "com.airship.dotnet/event/deep_link_received" },
@@ -36,7 +34,6 @@ namespace AirshipDotNet.Events
             { AirshipEventType.MessageCenterUpdated, "com.airship.dotnet/event/message_center_updated" },
             { AirshipEventType.PushTokenReceived, "com.airship.dotnet/event/push_token_received" },
             { AirshipEventType.PushReceived, "com.airship.dotnet/event/push_received" },
-            { AirshipEventType.BackgroundPushReceived, "com.airship.dotnet/event/background_push_received" },
             { AirshipEventType.NotificationStatusChanged, "com.airship.dotnet/event/notification_status_changed" },
             { AirshipEventType.PendingEmbeddedUpdated, "com.airship.dotnet/event/pending_embedded_updated" },
             { AirshipEventType.AuthorizedNotificationSettingsChanged, "com.airship.dotnet/event/ios_authorized_notification_settings_changed" }

--- a/src/Airship.Net/Events/AirshipEventType.cs
+++ b/src/Airship.Net/Events/AirshipEventType.cs
@@ -18,24 +18,9 @@ namespace AirshipDotNet.Events
         PushReceived,
 
         /// <summary>
-        /// Fired when a background push notification is received.
-        /// </summary>
-        BackgroundPushReceived,
-
-        /// <summary>
-        /// Fired when a push notification response is received.
+        /// Fired when the user interacts with a push notification.
         /// </summary>
         NotificationResponse,
-
-        /// <summary>
-        /// Fired when a background notification response is received.
-        /// </summary>
-        BackgroundNotificationResponse,
-
-        /// <summary>
-        /// Fired when a foreground notification response is received.
-        /// </summary>
-        ForegroundNotificationResponse,
 
         /// <summary>
         /// Fired when push notification status changes.

--- a/src/Airship.Net/IAirshipMessageCenter.cs
+++ b/src/Airship.Net/IAirshipMessageCenter.cs
@@ -58,15 +58,5 @@ namespace AirshipDotNet
         /// </summary>
         /// <param name="messageId">The message ID to display.</param>
         Task DisplayMessage(string messageId);
-
-        /// <summary>
-        /// Add/remove the Message Center display listener.
-        /// </summary>
-        public event EventHandler<MessageCenterEventArgs> OnMessageCenterDisplay;
-
-        /// <summary>
-        /// Add/remove the Message Center updated listener.
-        /// </summary>
-        public event EventHandler<EventArgs> OnMessagesUpdated;
     }
 }

--- a/src/Airship.Net/Platforms/Android/Airship.cs
+++ b/src/Airship.Net/Platforms/Android/Airship.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Android.OS;
 using Com.Urbanairship.Contacts;
 using Java.Util;
 using Java.Util.Concurrent;
@@ -10,6 +11,7 @@ using UrbanAirship.Automation;
 using UrbanAirship.Actions;
 using UrbanAirship.Channel;
 using UrbanAirship.Push;
+using UrbanAirship.PreferenceCenter;
 using AirshipDotNet.Events;
 using AirshipDotNet.MessageCenter;
 using AirshipDotNet.Platforms.Android;
@@ -20,7 +22,14 @@ namespace AirshipDotNet
     /// <summary>
     /// Provides cross-platform access to a common subset of functionality between the iOS and Android SDKs
     /// </summary>
-    public class Airship : Java.Lang.Object, IDeepLinkListener, UrbanAirship.Channel.IAirshipChannelListener, IPushNotificationStatusListener, UrbanAirship.MessageCenter.IInboxListener
+    public class Airship : Java.Lang.Object,
+        IDeepLinkListener,
+        UrbanAirship.Channel.IAirshipChannelListener,
+        IPushNotificationStatusListener,
+        UrbanAirship.MessageCenter.IInboxListener,
+        IPushTokenListener,
+        IPushListener,
+        INotificationListener
     {
         private static readonly Lazy<Airship> sharedAirship = new(() =>
         {
@@ -36,6 +45,16 @@ namespace AirshipDotNet
         private readonly Dictionary<EventHandler<ChannelEventArgs>, EventHandler<EventArgs>> _channelHandlerMap = new();
         private readonly Dictionary<EventHandler<PushNotificationStatusEventArgs>, EventHandler<EventArgs>> _pushStatusHandlerMap = new();
         private readonly Dictionary<EventHandler<DeepLinkEventArgs>, EventHandler<EventArgs>> _deepLinkHandlerMap = new();
+        private readonly Dictionary<EventHandler<PushReceivedEventArgs>, EventHandler<EventArgs>> _pushReceivedHandlerMap = new();
+        private readonly Dictionary<EventHandler<NotificationResponseEventArgs>, EventHandler<EventArgs>> _notificationResponseHandlerMap = new();
+        private readonly Dictionary<EventHandler<PushTokenReceivedEventArgs>, EventHandler<EventArgs>> _pushTokenHandlerMap = new();
+        private readonly Dictionary<EventHandler<MessageCenterEventArgs>, EventHandler<EventArgs>> _displayMessageCenterHandlerMap = new();
+        private readonly Dictionary<EventHandler<EventArgs>, EventHandler<EventArgs>> _messageCenterUpdatedHandlerMap = new();
+        private readonly Dictionary<EventHandler<PreferenceCenterEventArgs>, EventHandler<EventArgs>> _displayPreferenceCenterHandlerMap = new();
+
+        // Strong references for delegates / listeners that are held weakly or by interface
+        private AirshipMessageCenterDisplayDelegate? _messageCenterDisplayDelegate;
+        private AirshipPreferenceCenterOpenDelegate? _preferenceCenterOpenDelegate;
 
         // Module instances
         private readonly AirshipModule _module;
@@ -71,9 +90,10 @@ namespace AirshipDotNet
         private void Init()
         {
             UAirship.Shared().Channel.AddChannelListener(this);
-
-            //Adding Push notification status listener
             UAirship.Shared().PushManager.AddNotificationStatusListener(this);
+            UAirship.Shared().PushManager.AddPushTokenListener(this);
+            UAirship.Shared().PushManager.AddPushListener(this);
+            UAirship.Shared().PushManager.NotificationListener = this;
 
             UrbanAirship.MessageCenter.MessageCenterClass.Shared().Inbox.AddListener(this);
 
@@ -99,7 +119,6 @@ namespace AirshipDotNet
             {
                 if (value != null)
                 {
-                    // Create and store wrapper handler to prevent memory leak
                     EventHandler<EventArgs> wrapper = (sender, args) =>
                         value(this, args as ChannelEventArgs ?? new ChannelEventArgs(""));
 
@@ -126,7 +145,6 @@ namespace AirshipDotNet
             {
                 if (value != null)
                 {
-                    // Create and store wrapper handler to prevent memory leak
                     EventHandler<EventArgs> wrapper = (sender, args) =>
                         value(this, args as PushNotificationStatusEventArgs ??
                             new PushNotificationStatusEventArgs(new PushNotificationStatus()));
@@ -146,11 +164,6 @@ namespace AirshipDotNet
         }
 
         /// <summary>
-        /// Add/remove the Message Center updated listener.
-        /// </summary>
-        internal event EventHandler<EventArgs>? OnMessagesUpdated;
-
-        /// <summary>
         /// Add/remove the deep link listener.
         /// </summary>
         public event EventHandler<DeepLinkEventArgs> OnDeepLinkReceived
@@ -159,7 +172,6 @@ namespace AirshipDotNet
             {
                 if (value != null)
                 {
-                    // Create and store wrapper handler to prevent memory leak
                     EventHandler<EventArgs> wrapper = (sender, args) =>
                         value(this, args as DeepLinkEventArgs ?? new DeepLinkEventArgs(""));
 
@@ -184,51 +196,187 @@ namespace AirshipDotNet
             }
         }
 
-        // Internal delegate class for Message Center display
-        internal class AirshipMessageCenterDisplayDelegate : Java.Lang.Object, UrbanAirship.MessageCenter.MessageCenterClass.IOnShowMessageCenterListener
-        {
-            private readonly Action<string?> handler;
-
-            public AirshipMessageCenterDisplayDelegate(Action<string?> handler)
-            {
-                this.handler = handler;
-            }
-
-            public bool OnShowMessageCenter(string? messageId)
-            {
-                handler?.Invoke(messageId);
-                return true;
-            }
-        }
-
-        private EventHandler<MessageCenterEventArgs>? onMessageCenterDisplay;
-        private AirshipMessageCenterDisplayDelegate? messageCenterDisplayDelegate;
-
         /// <summary>
-        /// Add/remove the Message Center display listener.
+        /// Add/remove the push received listener. Fires for both foreground and background pushes.
         /// </summary>
-        public event EventHandler<MessageCenterEventArgs> OnMessageCenterDisplay
+        public event EventHandler<PushReceivedEventArgs>? OnPushReceived
         {
             add
             {
-                onMessageCenterDisplay += value;
-                if (messageCenterDisplayDelegate == null)
+                if (value != null)
                 {
-                    messageCenterDisplayDelegate = new AirshipMessageCenterDisplayDelegate((messageId) =>
-                    {
-                        onMessageCenterDisplay?.Invoke(this, new MessageCenterEventArgs(messageId));
-                    });
-                    UrbanAirship.MessageCenter.MessageCenterClass.Shared().SetOnShowMessageCenterListener(messageCenterDisplayDelegate);
+                    EventHandler<EventArgs> wrapper = (sender, args) =>
+                        value(this, (args as PushReceivedEventArgs)!);
+
+                    _pushReceivedHandlerMap[value] = wrapper;
+                    AirshipEventEmitter.Shared.AddListener(AirshipEventType.PushReceived, wrapper);
                 }
             }
             remove
             {
-                onMessageCenterDisplay -= value;
+                if (value != null && _pushReceivedHandlerMap.TryGetValue(value, out var wrapper))
+                {
+                    AirshipEventEmitter.Shared.RemoveListener(AirshipEventType.PushReceived, wrapper);
+                    _pushReceivedHandlerMap.Remove(value);
+                }
+            }
+        }
 
-                if (onMessageCenterDisplay == null)
+        /// <summary>
+        /// Add/remove the notification response listener (user tap or action button).
+        /// </summary>
+        public event EventHandler<NotificationResponseEventArgs>? OnNotificationResponse
+        {
+            add
+            {
+                if (value != null)
+                {
+                    EventHandler<EventArgs> wrapper = (sender, args) =>
+                        value(this, (args as NotificationResponseEventArgs)!);
+
+                    _notificationResponseHandlerMap[value] = wrapper;
+                    AirshipEventEmitter.Shared.AddListener(AirshipEventType.NotificationResponse, wrapper);
+                }
+            }
+            remove
+            {
+                if (value != null && _notificationResponseHandlerMap.TryGetValue(value, out var wrapper))
+                {
+                    AirshipEventEmitter.Shared.RemoveListener(AirshipEventType.NotificationResponse, wrapper);
+                    _notificationResponseHandlerMap.Remove(value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Add/remove the push token received listener.
+        /// </summary>
+        public event EventHandler<PushTokenReceivedEventArgs>? OnPushTokenReceived
+        {
+            add
+            {
+                if (value != null)
+                {
+                    EventHandler<EventArgs> wrapper = (sender, args) =>
+                        value(this, (args as PushTokenReceivedEventArgs)!);
+
+                    _pushTokenHandlerMap[value] = wrapper;
+                    AirshipEventEmitter.Shared.AddListener(AirshipEventType.PushTokenReceived, wrapper);
+                }
+            }
+            remove
+            {
+                if (value != null && _pushTokenHandlerMap.TryGetValue(value, out var wrapper))
+                {
+                    AirshipEventEmitter.Shared.RemoveListener(AirshipEventType.PushTokenReceived, wrapper);
+                    _pushTokenHandlerMap.Remove(value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Add/remove the message center display request listener.
+        /// </summary>
+        public event EventHandler<MessageCenterEventArgs>? OnDisplayMessageCenter
+        {
+            add
+            {
+                if (value != null)
+                {
+                    EventHandler<EventArgs> wrapper = (sender, args) =>
+                        value(this, args as MessageCenterEventArgs ?? new MessageCenterEventArgs(null));
+
+                    _displayMessageCenterHandlerMap[value] = wrapper;
+                    AirshipEventEmitter.Shared.AddListener(AirshipEventType.DisplayMessageCenter, wrapper);
+
+                    if (_messageCenterDisplayDelegate == null)
+                    {
+                        _messageCenterDisplayDelegate = new AirshipMessageCenterDisplayDelegate((messageId) =>
+                        {
+                            AirshipEventEmitter.Shared.Emit(AirshipEventType.DisplayMessageCenter, new MessageCenterEventArgs(messageId));
+                        });
+                        UrbanAirship.MessageCenter.MessageCenterClass.Shared().SetOnShowMessageCenterListener(_messageCenterDisplayDelegate);
+                    }
+                }
+            }
+            remove
+            {
+                if (value != null && _displayMessageCenterHandlerMap.TryGetValue(value, out var wrapper))
+                {
+                    AirshipEventEmitter.Shared.RemoveListener(AirshipEventType.DisplayMessageCenter, wrapper);
+                    _displayMessageCenterHandlerMap.Remove(value);
+                }
+
+                if (_displayMessageCenterHandlerMap.Count == 0 && _messageCenterDisplayDelegate != null)
                 {
                     UrbanAirship.MessageCenter.MessageCenterClass.Shared().SetOnShowMessageCenterListener(null);
-                    messageCenterDisplayDelegate = null;
+                    _messageCenterDisplayDelegate = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Add/remove the message center inbox updated listener.
+        /// </summary>
+        public event EventHandler<EventArgs>? OnMessageCenterUpdated
+        {
+            add
+            {
+                if (value != null)
+                {
+                    EventHandler<EventArgs> wrapper = (sender, args) => value(this, args);
+
+                    _messageCenterUpdatedHandlerMap[value] = wrapper;
+                    AirshipEventEmitter.Shared.AddListener(AirshipEventType.MessageCenterUpdated, wrapper);
+                }
+            }
+            remove
+            {
+                if (value != null && _messageCenterUpdatedHandlerMap.TryGetValue(value, out var wrapper))
+                {
+                    AirshipEventEmitter.Shared.RemoveListener(AirshipEventType.MessageCenterUpdated, wrapper);
+                    _messageCenterUpdatedHandlerMap.Remove(value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Add/remove the preference center display request listener.
+        /// </summary>
+        public event EventHandler<PreferenceCenterEventArgs>? OnDisplayPreferenceCenter
+        {
+            add
+            {
+                if (value != null)
+                {
+                    EventHandler<EventArgs> wrapper = (sender, args) =>
+                        value(this, (args as PreferenceCenterEventArgs)!);
+
+                    _displayPreferenceCenterHandlerMap[value] = wrapper;
+                    AirshipEventEmitter.Shared.AddListener(AirshipEventType.DisplayPreferenceCenter, wrapper);
+
+                    if (_preferenceCenterOpenDelegate == null)
+                    {
+                        _preferenceCenterOpenDelegate = new AirshipPreferenceCenterOpenDelegate((preferenceCenterId) =>
+                        {
+                            AirshipEventEmitter.Shared.Emit(AirshipEventType.DisplayPreferenceCenter, new PreferenceCenterEventArgs(preferenceCenterId));
+                        });
+                        global::UrbanAirship.PreferenceCenter.PreferenceCenter.Shared().OpenListener = _preferenceCenterOpenDelegate;
+                    }
+                }
+            }
+            remove
+            {
+                if (value != null && _displayPreferenceCenterHandlerMap.TryGetValue(value, out var wrapper))
+                {
+                    AirshipEventEmitter.Shared.RemoveListener(AirshipEventType.DisplayPreferenceCenter, wrapper);
+                    _displayPreferenceCenterHandlerMap.Remove(value);
+                }
+
+                if (_displayPreferenceCenterHandlerMap.Count == 0 && _preferenceCenterOpenDelegate != null)
+                {
+                    global::UrbanAirship.PreferenceCenter.PreferenceCenter.Shared().OpenListener = null;
+                    _preferenceCenterOpenDelegate = null;
                 }
             }
         }
@@ -293,6 +441,99 @@ namespace AirshipDotNet
             AirshipEventEmitter.Shared.Emit(AirshipEventType.NotificationStatusChanged, new PushNotificationStatusEventArgs(pushStatus));
         }
 
-        public void OnInboxUpdated() => OnMessagesUpdated?.Invoke(this, new EventArgs());
+        public void OnInboxUpdated()
+        {
+            AirshipEventEmitter.Shared.Emit(AirshipEventType.MessageCenterUpdated, EventArgs.Empty);
+        }
+
+        public void OnPushTokenUpdated(string token)
+        {
+            AirshipEventEmitter.Shared.Emit(AirshipEventType.PushTokenReceived, new PushTokenReceivedEventArgs(token));
+        }
+
+        void IPushListener.OnPushReceived(PushMessage message, bool notificationPosted)
+        {
+            var args = BuildPushReceivedEventArgs(message, isBackground: !notificationPosted);
+            AirshipEventEmitter.Shared.Emit(AirshipEventType.PushReceived, args);
+        }
+
+        public void OnNotificationPosted(NotificationInfo notificationInfo) { }
+
+        public bool OnNotificationOpened(NotificationInfo notificationInfo)
+        {
+            var push = BuildPushReceivedEventArgs(notificationInfo.Message, isBackground: false);
+            AirshipEventEmitter.Shared.Emit(AirshipEventType.NotificationResponse,
+                new NotificationResponseEventArgs(push, actionId: null, isForeground: true));
+            return false;
+        }
+
+        public bool OnNotificationForegroundAction(NotificationInfo notificationInfo, NotificationActionButtonInfo actionButtonInfo)
+        {
+            var push = BuildPushReceivedEventArgs(notificationInfo.Message, isBackground: false);
+            AirshipEventEmitter.Shared.Emit(AirshipEventType.NotificationResponse,
+                new NotificationResponseEventArgs(push, actionButtonInfo.ButtonId, isForeground: true));
+            return false;
+        }
+
+        public void OnNotificationBackgroundAction(NotificationInfo notificationInfo, NotificationActionButtonInfo actionButtonInfo)
+        {
+            var push = BuildPushReceivedEventArgs(notificationInfo.Message, isBackground: false);
+            AirshipEventEmitter.Shared.Emit(AirshipEventType.NotificationResponse,
+                new NotificationResponseEventArgs(push, actionButtonInfo.ButtonId, isForeground: false));
+        }
+
+        public void OnNotificationDismissed(NotificationInfo notificationInfo) { }
+
+        private static PushReceivedEventArgs BuildPushReceivedEventArgs(PushMessage message, bool isBackground)
+        {
+            var payload = BundleToDictionary(message.PushBundle);
+            return new PushReceivedEventArgs(payload, message.Alert, message.Title, isBackground);
+        }
+
+        private static IDictionary<string, object?> BundleToDictionary(Bundle? bundle)
+        {
+            var dict = new Dictionary<string, object?>();
+            if (bundle == null) return dict;
+
+            foreach (var key in bundle.KeySet() ?? new List<string>())
+            {
+                dict[key] = bundle.Get(key)?.ToString();
+            }
+            return dict;
+        }
+
+        // Inner delegate classes wrapping Airship Java listener interfaces.
+
+        internal class AirshipMessageCenterDisplayDelegate : Java.Lang.Object, UrbanAirship.MessageCenter.MessageCenterClass.IOnShowMessageCenterListener
+        {
+            private readonly Action<string?> handler;
+
+            public AirshipMessageCenterDisplayDelegate(Action<string?> handler)
+            {
+                this.handler = handler;
+            }
+
+            public bool OnShowMessageCenter(string? messageId)
+            {
+                handler?.Invoke(messageId);
+                return true;
+            }
+        }
+
+        internal class AirshipPreferenceCenterOpenDelegate : Java.Lang.Object, global::UrbanAirship.PreferenceCenter.PreferenceCenter.IOnOpenListener
+        {
+            private readonly Action<string> handler;
+
+            public AirshipPreferenceCenterOpenDelegate(Action<string> handler)
+            {
+                this.handler = handler;
+            }
+
+            public bool OnOpenPreferenceCenter(string preferenceCenterId)
+            {
+                handler?.Invoke(preferenceCenterId);
+                return true;
+            }
+        }
     }
 }

--- a/src/Airship.Net/Platforms/Android/Modules/AirshipMessageCenter.cs
+++ b/src/Airship.Net/Platforms/Android/Modules/AirshipMessageCenter.cs
@@ -23,22 +23,6 @@ namespace AirshipDotNet.Platforms.Android.Modules
             _module = module;
         }
 
-        internal class AirshipMessageCenterDisplayDelegate : Java.Lang.Object, MessageCenterClass.IOnShowMessageCenterListener
-        {
-            private readonly Action<string?> handler;
-
-            public AirshipMessageCenterDisplayDelegate(Action<string?> handler)
-            {
-                this.handler = handler;
-            }
-
-            public bool OnShowMessageCenter(string? messageId)
-            {
-                handler?.Invoke(messageId);
-                return true;
-            }
-        }
-
         /// <summary>
         /// Displays the message center.
         /// </summary>
@@ -180,70 +164,6 @@ namespace AirshipDotNet.Platforms.Android.Modules
         {
             MessageCenterClass.Shared().Inbox.DeleteMessages(messageIds);
             return Task.CompletedTask;
-        }
-
-        private EventHandler<MessageCenterEventArgs>? onMessageCenterDisplay;
-        private AirshipMessageCenterDisplayDelegate? messageCenterDisplayDelegate;
-
-        /// <summary>
-        /// Add/remove the Message Center display listener.
-        /// </summary>
-        public event EventHandler<MessageCenterEventArgs> OnMessageCenterDisplay
-        {
-            add
-            {
-                onMessageCenterDisplay += value;
-                if (messageCenterDisplayDelegate == null)
-                {
-                    messageCenterDisplayDelegate = new AirshipMessageCenterDisplayDelegate((messageId) =>
-                    {
-                        onMessageCenterDisplay?.Invoke(this, new MessageCenterEventArgs(messageId));
-                    });
-                    MessageCenterClass.Shared().SetOnShowMessageCenterListener(messageCenterDisplayDelegate);
-                }
-            }
-            remove
-            {
-                onMessageCenterDisplay -= value;
-
-                if (onMessageCenterDisplay == null)
-                {
-                    MessageCenterClass.Shared().SetOnShowMessageCenterListener(null);
-                    messageCenterDisplayDelegate = null;
-                }
-            }
-        }
-
-        private EventHandler<EventArgs>? onMessagesUpdated;
-        private EventHandler<EventArgs>? airshipMessagesUpdatedHandler;
-
-        /// <summary>
-        /// Add/remove the Message Center updated listener.
-        /// </summary>
-        public event EventHandler<EventArgs> OnMessagesUpdated
-        {
-            add
-            {
-                onMessagesUpdated += value;
-                if (airshipMessagesUpdatedHandler == null)
-                {
-                    airshipMessagesUpdatedHandler = (sender, e) =>
-                    {
-                        onMessagesUpdated?.Invoke(this, e);
-                    };
-                    Airship.Instance.OnMessagesUpdated += airshipMessagesUpdatedHandler;
-                }
-            }
-            remove
-            {
-                onMessagesUpdated -= value;
-
-                if (onMessagesUpdated == null && airshipMessagesUpdatedHandler != null)
-                {
-                    Airship.Instance.OnMessagesUpdated -= airshipMessagesUpdatedHandler;
-                    airshipMessagesUpdatedHandler = null;
-                }
-            }
         }
 
         private static DateTime? FromDate(Date? date)

--- a/src/Airship.Net/Platforms/iOS/Airship.cs
+++ b/src/Airship.Net/Platforms/iOS/Airship.cs
@@ -2,7 +2,10 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Foundation;
+using UIKit;
+using UserNotifications;
 using Airship;
 using AirshipDotNet.Analytics;
 using AirshipDotNet.Attributes;
@@ -30,6 +33,121 @@ namespace AirshipDotNet
         }
     }
 
+    internal class AirshipPushNotificationDelegate : global::Airship.UAPushNotificationDelegate
+    {
+        private readonly Action<NSDictionary, bool> onReceived;
+        private readonly Action<UNNotificationResponse> onResponse;
+
+        public AirshipPushNotificationDelegate(Action<NSDictionary, bool> onReceived, Action<UNNotificationResponse> onResponse)
+        {
+            this.onReceived = onReceived;
+            this.onResponse = onResponse;
+        }
+
+        public override void ReceivedForegroundNotification(NSDictionary userInfo, Action completionHandler)
+        {
+            onReceived?.Invoke(userInfo, false);
+            completionHandler();
+        }
+
+        public override void ReceivedBackgroundNotification(NSDictionary userInfo, Action<UIBackgroundFetchResult> completionHandler)
+        {
+            onReceived?.Invoke(userInfo, true);
+            completionHandler(UIBackgroundFetchResult.NoData);
+        }
+
+        public override void ReceivedNotificationResponse(UNNotificationResponse notificationResponse, Action completionHandler)
+        {
+            onResponse?.Invoke(notificationResponse);
+            completionHandler();
+        }
+
+        public override void ExtendPresentationOptions(UNNotificationPresentationOptions options, UNNotification notification, Action<UNNotificationPresentationOptions> completionHandler)
+        {
+            completionHandler(options);
+        }
+    }
+
+    internal class AirshipRegistrationDelegate : global::Airship.UARegistrationDelegate
+    {
+        private readonly Action<string> onTokenReceived;
+        private readonly Action<UAAuthorizedNotificationSettings> onSettingsChanged;
+
+        public AirshipRegistrationDelegate(Action<string> onTokenReceived, Action<UAAuthorizedNotificationSettings> onSettingsChanged)
+        {
+            this.onTokenReceived = onTokenReceived;
+            this.onSettingsChanged = onSettingsChanged;
+        }
+
+        public override void NotificationRegistrationFinishedWithAuthorizedSettings(UAAuthorizedNotificationSettings authorizedSettings, NSSet<UNNotificationCategory> categories, UNAuthorizationStatus status) { }
+
+        public override void NotificationRegistrationFinishedWithAuthorizedSettings(UAAuthorizedNotificationSettings authorizedSettings, UNAuthorizationStatus status) { }
+
+        public override void NotificationAuthorizedSettingsDidChange(UAAuthorizedNotificationSettings authorizedSettings)
+        {
+            onSettingsChanged?.Invoke(authorizedSettings);
+        }
+
+        public override void ApnsRegistrationSucceededWithDeviceToken(NSData deviceToken)
+        {
+            onTokenReceived?.Invoke(HexFromData(deviceToken));
+        }
+
+        public override void ApnsRegistrationFailedWithError(NSError error) { }
+
+        private static string HexFromData(NSData data)
+        {
+            var bytes = data.ToArray();
+            var sb = new StringBuilder(bytes.Length * 2);
+            foreach (var b in bytes)
+            {
+                sb.Append(b.ToString("x2"));
+            }
+            return sb.ToString();
+        }
+    }
+
+    internal class AirshipPreferenceCenterOpenDelegate : global::Airship.UAPreferenceCenterOpenDelegate
+    {
+        private readonly Action<string> handler;
+
+        public AirshipPreferenceCenterOpenDelegate(Action<string> handler)
+        {
+            this.handler = handler;
+        }
+
+        public override bool OpenPreferenceCenter(string preferenceCenterID)
+        {
+            handler?.Invoke(preferenceCenterID);
+            return true;
+        }
+    }
+
+    internal class AirshipMessageCenterDisplayDelegate : global::Airship.UAMessageCenterDisplayDelegate
+    {
+        private readonly Action<string?> handler;
+
+        public AirshipMessageCenterDisplayDelegate(Action<string?> handler)
+        {
+            this.handler = handler;
+        }
+
+        public override void DisplayMessageCenterForMessageID(string messageId)
+        {
+            handler?.Invoke(messageId);
+        }
+
+        public override void DisplayMessageCenter()
+        {
+            handler?.Invoke(null);
+        }
+
+        public override void DismissMessageCenter()
+        {
+            handler?.Invoke(null);
+        }
+    }
+
 
     /// <summary>
     /// Provides cross-platform access to a common subset of functionality between the iOS and Android SDKs
@@ -50,6 +168,13 @@ namespace AirshipDotNet
         private readonly Dictionary<EventHandler<ChannelEventArgs>, EventHandler<EventArgs>> _channelHandlerMap = new();
         private readonly Dictionary<EventHandler<PushNotificationStatusEventArgs>, EventHandler<EventArgs>> _pushStatusHandlerMap = new();
         private readonly Dictionary<EventHandler<DeepLinkEventArgs>, EventHandler<EventArgs>> _deepLinkHandlerMap = new();
+        private readonly Dictionary<EventHandler<PushReceivedEventArgs>, EventHandler<EventArgs>> _pushReceivedHandlerMap = new();
+        private readonly Dictionary<EventHandler<NotificationResponseEventArgs>, EventHandler<EventArgs>> _notificationResponseHandlerMap = new();
+        private readonly Dictionary<EventHandler<PushTokenReceivedEventArgs>, EventHandler<EventArgs>> _pushTokenHandlerMap = new();
+        private readonly Dictionary<EventHandler<MessageCenterEventArgs>, EventHandler<EventArgs>> _displayMessageCenterHandlerMap = new();
+        private readonly Dictionary<EventHandler<EventArgs>, EventHandler<EventArgs>> _messageCenterUpdatedHandlerMap = new();
+        private readonly Dictionary<EventHandler<PreferenceCenterEventArgs>, EventHandler<EventArgs>> _displayPreferenceCenterHandlerMap = new();
+        private readonly Dictionary<EventHandler<IOSAuthorizedNotificationSettingsEventArgs>, EventHandler<EventArgs>> _authorizedSettingsHandlerMap = new();
 
         // Module instances
         private readonly AirshipModule _module;
@@ -63,6 +188,13 @@ namespace AirshipDotNet
         private readonly IAirshipPreferenceCenter _preferenceCenter;
         private readonly IAirshipMessageCenter _messageCenter;
         private readonly IAirshipPermissionsManager _permissionsManager;
+
+        // Strong references for delegates Airship binds weakly
+        private AirshipDeepLinkDelegate? _deepLinkDelegate;
+        private AirshipPushNotificationDelegate? _pushNotificationDelegate;
+        private AirshipRegistrationDelegate? _registrationDelegate;
+        private AirshipPreferenceCenterOpenDelegate? _preferenceCenterOpenDelegate;
+        private AirshipMessageCenterDisplayDelegate? _messageCenterDisplayDelegate;
 
         public Airship()
         {
@@ -88,16 +220,44 @@ namespace AirshipDotNet
             NSNotificationCenter.DefaultCenter.AddObserver(aName: (NSString)UAirshipNotificationChannelCreated.Name, (notification) =>
             {
                 string channelID = notification.UserInfo?[UAirshipNotificationChannelCreated.ChannelIDKey]?.ToString() ?? "";
-                var eventArgs = new ChannelEventArgs(channelID);
-
-                AirshipEventEmitter.Shared.Emit(AirshipEventType.ChannelCreated, eventArgs);
+                AirshipEventEmitter.Shared.Emit(AirshipEventType.ChannelCreated, new ChannelEventArgs(channelID));
             });
 
-            // Message Center updated notification
-            NSNotificationCenter.DefaultCenter.AddObserver(aName: (NSString)"com.urbanairship.notification.message_list_updated", (notification) =>
+            // Message Center inbox updated notification
+            NSNotificationCenter.DefaultCenter.AddObserver(aName: (NSString)"com.urbanairship.notification.message_list_updated", (_) =>
             {
-                OnMessagesUpdated?.Invoke(this, new EventArgs());
+                AirshipEventEmitter.Shared.Emit(AirshipEventType.MessageCenterUpdated, EventArgs.Empty);
             });
+
+            // Push (foreground/background) and notification response
+            _pushNotificationDelegate = new AirshipPushNotificationDelegate(
+                onReceived: (userInfo, isBackground) =>
+                {
+                    AirshipEventEmitter.Shared.Emit(AirshipEventType.PushReceived, BuildPushReceivedEventArgs(userInfo, isBackground));
+                },
+                onResponse: (response) =>
+                {
+                    var userInfo = response.Notification.Request.Content.UserInfo;
+                    var push = BuildPushReceivedEventArgs(userInfo, isBackground: false);
+                    var actionId = response.ActionIdentifier == "com.apple.UNNotificationDefaultActionIdentifier" ? null : response.ActionIdentifier;
+                    AirshipEventEmitter.Shared.Emit(AirshipEventType.NotificationResponse, new NotificationResponseEventArgs(push, actionId, isForeground: true));
+                });
+            UAirship.Push.PushNotificationDelegate = _pushNotificationDelegate;
+
+            // Push token + authorized settings changes
+            _registrationDelegate = new AirshipRegistrationDelegate(
+                onTokenReceived: (token) =>
+                {
+                    AirshipEventEmitter.Shared.Emit(AirshipEventType.PushTokenReceived, new PushTokenReceivedEventArgs(token));
+                },
+                onSettingsChanged: (settings) =>
+                {
+                    // UAAuthorizedNotificationSettings is a Swift OptionSet wrapper whose
+                    // rawValue is not exposed via the current ObjC binding (no @objc accessor,
+                    // not KVC-compliant). Emit 0 until the binding surfaces the raw bitmask.
+                    AirshipEventEmitter.Shared.Emit(AirshipEventType.AuthorizedNotificationSettingsChanged, new IOSAuthorizedNotificationSettingsEventArgs(0));
+                });
+            UAirship.Push.RegistrationDelegate = _registrationDelegate;
 
             // Subscribe to pending events when listeners are added
             AirshipEventEmitter.Shared.PendingEventAvailable += OnPendingEventAvailable;
@@ -113,11 +273,6 @@ namespace AirshipDotNet
         }
 
         /// <summary>
-        /// Add/remove the Message Center updated listener.
-        /// </summary>
-        internal event EventHandler<EventArgs>? OnMessagesUpdated;
-
-        /// <summary>
         /// Add/remove the channel creation listener.
         /// </summary>
         public event EventHandler<ChannelEventArgs>? OnChannelCreation
@@ -126,7 +281,6 @@ namespace AirshipDotNet
             {
                 if (value != null)
                 {
-                    // Create and store wrapper handler to prevent memory leak
                     EventHandler<EventArgs> wrapper = (sender, args) =>
                         value(this, args as ChannelEventArgs ?? new ChannelEventArgs(""));
 
@@ -153,7 +307,6 @@ namespace AirshipDotNet
             {
                 if (value != null)
                 {
-                    // Create and store wrapper handler to prevent memory leak
                     EventHandler<EventArgs> wrapper = (sender, args) =>
                         value(this, args as PushNotificationStatusEventArgs ??
                             new PushNotificationStatusEventArgs(new PushNotificationStatus()));
@@ -172,8 +325,6 @@ namespace AirshipDotNet
             }
         }
 
-        private AirshipDeepLinkDelegate? deepLinkDelegate;
-
         /// <summary>
         /// Add/remove the deep link listener.
         /// </summary>
@@ -183,7 +334,6 @@ namespace AirshipDotNet
             {
                 if (value != null)
                 {
-                    // Create and store wrapper handler to prevent memory leak
                     EventHandler<EventArgs> wrapper = (sender, args) =>
                         value(this, args as DeepLinkEventArgs ?? new DeepLinkEventArgs(""));
 
@@ -191,15 +341,13 @@ namespace AirshipDotNet
                     AirshipEventEmitter.Shared.AddListener(AirshipEventType.DeepLinkReceived, wrapper);
                 }
 
-                if (deepLinkDelegate == null)
+                if (_deepLinkDelegate == null)
                 {
-                    deepLinkDelegate = new AirshipDeepLinkDelegate((deepLink) =>
+                    _deepLinkDelegate = new AirshipDeepLinkDelegate((deepLink) =>
                     {
-                        var eventArgs = new DeepLinkEventArgs(deepLink);
-
-                        AirshipEventEmitter.Shared.Emit(AirshipEventType.DeepLinkReceived, eventArgs);
+                        AirshipEventEmitter.Shared.Emit(AirshipEventType.DeepLinkReceived, new DeepLinkEventArgs(deepLink));
                     });
-                    UAirship.DeepLinkDelegate = deepLinkDelegate;
+                    UAirship.DeepLinkDelegate = _deepLinkDelegate;
                 }
             }
             remove
@@ -213,65 +361,218 @@ namespace AirshipDotNet
                 if (_deepLinkHandlerMap.Count == 0)
                 {
                     UAirship.DeepLinkDelegate = null;
-                    deepLinkDelegate = null;
+                    _deepLinkDelegate = null;
                 }
             }
         }
 
-        // Internal delegate class for Message Center display
-        internal class AirshipMessageCenterDisplayDelegate : global::Airship.UAMessageCenterDisplayDelegate
-        {
-            private readonly Action<string?> handler;
-
-            public AirshipMessageCenterDisplayDelegate(Action<string?> handler)
-            {
-                this.handler = handler;
-            }
-
-            public override void DisplayMessageCenterForMessageID(string messageId)
-            {
-                handler?.Invoke(messageId);
-            }
-
-            public override void DisplayMessageCenter()
-            {
-                handler?.Invoke(null);
-            }
-
-            public override void DismissMessageCenter()
-            {
-                handler?.Invoke(null);
-            }
-        }
-
-        private EventHandler<MessageCenterEventArgs>? onMessageCenterDisplay;
-        private AirshipMessageCenterDisplayDelegate? messageCenterDisplayDelegate;
-
         /// <summary>
-        /// Add/remove the Message Center display listener.
+        /// Add/remove the push received listener. Fires for both foreground and background pushes.
         /// </summary>
-        public event EventHandler<MessageCenterEventArgs> OnMessageCenterDisplay
+        public event EventHandler<PushReceivedEventArgs>? OnPushReceived
         {
             add
             {
-                onMessageCenterDisplay += value;
-                if (messageCenterDisplayDelegate == null)
+                if (value != null)
                 {
-                    messageCenterDisplayDelegate = new AirshipMessageCenterDisplayDelegate((messageId) =>
-                    {
-                        onMessageCenterDisplay?.Invoke(this, new MessageCenterEventArgs(messageId));
-                    });
-                    UAirship.MessageCenter.WeakDisplayDelegate = messageCenterDisplayDelegate;
+                    EventHandler<EventArgs> wrapper = (sender, args) =>
+                        value(this, (args as PushReceivedEventArgs)!);
+
+                    _pushReceivedHandlerMap[value] = wrapper;
+                    AirshipEventEmitter.Shared.AddListener(AirshipEventType.PushReceived, wrapper);
                 }
             }
             remove
             {
-                onMessageCenterDisplay -= value;
-
-                if (onMessageCenterDisplay == null)
+                if (value != null && _pushReceivedHandlerMap.TryGetValue(value, out var wrapper))
                 {
-                    UAirship.MessageCenter.WeakDisplayDelegate = null;
-                    messageCenterDisplayDelegate = null;
+                    AirshipEventEmitter.Shared.RemoveListener(AirshipEventType.PushReceived, wrapper);
+                    _pushReceivedHandlerMap.Remove(value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Add/remove the notification response listener (user tap or action button).
+        /// </summary>
+        public event EventHandler<NotificationResponseEventArgs>? OnNotificationResponse
+        {
+            add
+            {
+                if (value != null)
+                {
+                    EventHandler<EventArgs> wrapper = (sender, args) =>
+                        value(this, (args as NotificationResponseEventArgs)!);
+
+                    _notificationResponseHandlerMap[value] = wrapper;
+                    AirshipEventEmitter.Shared.AddListener(AirshipEventType.NotificationResponse, wrapper);
+                }
+            }
+            remove
+            {
+                if (value != null && _notificationResponseHandlerMap.TryGetValue(value, out var wrapper))
+                {
+                    AirshipEventEmitter.Shared.RemoveListener(AirshipEventType.NotificationResponse, wrapper);
+                    _notificationResponseHandlerMap.Remove(value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Add/remove the push token received listener.
+        /// </summary>
+        public event EventHandler<PushTokenReceivedEventArgs>? OnPushTokenReceived
+        {
+            add
+            {
+                if (value != null)
+                {
+                    EventHandler<EventArgs> wrapper = (sender, args) =>
+                        value(this, (args as PushTokenReceivedEventArgs)!);
+
+                    _pushTokenHandlerMap[value] = wrapper;
+                    AirshipEventEmitter.Shared.AddListener(AirshipEventType.PushTokenReceived, wrapper);
+                }
+            }
+            remove
+            {
+                if (value != null && _pushTokenHandlerMap.TryGetValue(value, out var wrapper))
+                {
+                    AirshipEventEmitter.Shared.RemoveListener(AirshipEventType.PushTokenReceived, wrapper);
+                    _pushTokenHandlerMap.Remove(value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Add/remove the message center display request listener.
+        /// </summary>
+        public event EventHandler<MessageCenterEventArgs>? OnDisplayMessageCenter
+        {
+            add
+            {
+                if (value != null)
+                {
+                    EventHandler<EventArgs> wrapper = (sender, args) =>
+                        value(this, args as MessageCenterEventArgs ?? new MessageCenterEventArgs(null));
+
+                    _displayMessageCenterHandlerMap[value] = wrapper;
+                    AirshipEventEmitter.Shared.AddListener(AirshipEventType.DisplayMessageCenter, wrapper);
+
+                    if (_messageCenterDisplayDelegate == null)
+                    {
+                        _messageCenterDisplayDelegate = new AirshipMessageCenterDisplayDelegate((messageId) =>
+                        {
+                            AirshipEventEmitter.Shared.Emit(AirshipEventType.DisplayMessageCenter, new MessageCenterEventArgs(messageId));
+                        });
+                        UAirship.MessageCenter.DisplayDelegate = _messageCenterDisplayDelegate;
+                    }
+                }
+            }
+            remove
+            {
+                if (value != null && _displayMessageCenterHandlerMap.TryGetValue(value, out var wrapper))
+                {
+                    AirshipEventEmitter.Shared.RemoveListener(AirshipEventType.DisplayMessageCenter, wrapper);
+                    _displayMessageCenterHandlerMap.Remove(value);
+                }
+
+                if (_displayMessageCenterHandlerMap.Count == 0 && _messageCenterDisplayDelegate != null)
+                {
+                    UAirship.MessageCenter.DisplayDelegate = null;
+                    _messageCenterDisplayDelegate = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Add/remove the message center inbox updated listener.
+        /// </summary>
+        public event EventHandler<EventArgs>? OnMessageCenterUpdated
+        {
+            add
+            {
+                if (value != null)
+                {
+                    EventHandler<EventArgs> wrapper = (sender, args) => value(this, args);
+
+                    _messageCenterUpdatedHandlerMap[value] = wrapper;
+                    AirshipEventEmitter.Shared.AddListener(AirshipEventType.MessageCenterUpdated, wrapper);
+                }
+            }
+            remove
+            {
+                if (value != null && _messageCenterUpdatedHandlerMap.TryGetValue(value, out var wrapper))
+                {
+                    AirshipEventEmitter.Shared.RemoveListener(AirshipEventType.MessageCenterUpdated, wrapper);
+                    _messageCenterUpdatedHandlerMap.Remove(value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Add/remove the preference center display request listener.
+        /// </summary>
+        public event EventHandler<PreferenceCenterEventArgs>? OnDisplayPreferenceCenter
+        {
+            add
+            {
+                if (value != null)
+                {
+                    EventHandler<EventArgs> wrapper = (sender, args) =>
+                        value(this, (args as PreferenceCenterEventArgs)!);
+
+                    _displayPreferenceCenterHandlerMap[value] = wrapper;
+                    AirshipEventEmitter.Shared.AddListener(AirshipEventType.DisplayPreferenceCenter, wrapper);
+
+                    if (_preferenceCenterOpenDelegate == null)
+                    {
+                        _preferenceCenterOpenDelegate = new AirshipPreferenceCenterOpenDelegate((preferenceCenterID) =>
+                        {
+                            AirshipEventEmitter.Shared.Emit(AirshipEventType.DisplayPreferenceCenter, new PreferenceCenterEventArgs(preferenceCenterID));
+                        });
+                        UAirship.PreferenceCenter.OpenDelegate = _preferenceCenterOpenDelegate;
+                    }
+                }
+            }
+            remove
+            {
+                if (value != null && _displayPreferenceCenterHandlerMap.TryGetValue(value, out var wrapper))
+                {
+                    AirshipEventEmitter.Shared.RemoveListener(AirshipEventType.DisplayPreferenceCenter, wrapper);
+                    _displayPreferenceCenterHandlerMap.Remove(value);
+                }
+
+                if (_displayPreferenceCenterHandlerMap.Count == 0 && _preferenceCenterOpenDelegate != null)
+                {
+                    UAirship.PreferenceCenter.OpenDelegate = null;
+                    _preferenceCenterOpenDelegate = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Add/remove the iOS authorized notification settings change listener.
+        /// </summary>
+        public event EventHandler<IOSAuthorizedNotificationSettingsEventArgs>? OnAuthorizedNotificationSettingsChanged
+        {
+            add
+            {
+                if (value != null)
+                {
+                    EventHandler<EventArgs> wrapper = (sender, args) =>
+                        value(this, (args as IOSAuthorizedNotificationSettingsEventArgs)!);
+
+                    _authorizedSettingsHandlerMap[value] = wrapper;
+                    AirshipEventEmitter.Shared.AddListener(AirshipEventType.AuthorizedNotificationSettingsChanged, wrapper);
+                }
+            }
+            remove
+            {
+                if (value != null && _authorizedSettingsHandlerMap.TryGetValue(value, out var wrapper))
+                {
+                    AirshipEventEmitter.Shared.RemoveListener(AirshipEventType.AuthorizedNotificationSettingsChanged, wrapper);
+                    _authorizedSettingsHandlerMap.Remove(value);
                 }
             }
         }
@@ -310,6 +611,58 @@ namespace AirshipDotNet
                 tcs.TrySetResult(handled);
             });
             return tcs.Task;
+        }
+
+        private static PushReceivedEventArgs BuildPushReceivedEventArgs(NSDictionary userInfo, bool isBackground)
+        {
+            var payload = ToManagedDictionary(userInfo);
+            string? alert = null;
+            string? title = null;
+
+            if (payload.TryGetValue("aps", out var apsObj) && apsObj is IDictionary<string, object?> aps)
+            {
+                if (aps.TryGetValue("alert", out var alertObj))
+                {
+                    if (alertObj is IDictionary<string, object?> alertDict)
+                    {
+                        if (alertDict.TryGetValue("body", out var body)) alert = body?.ToString();
+                        if (alertDict.TryGetValue("title", out var t)) title = t?.ToString();
+                    }
+                    else
+                    {
+                        alert = alertObj?.ToString();
+                    }
+                }
+            }
+
+            return new PushReceivedEventArgs(payload, alert, title, isBackground);
+        }
+
+        private static IDictionary<string, object?> ToManagedDictionary(NSDictionary nsDict)
+        {
+            var dict = new Dictionary<string, object?>();
+            if (nsDict == null) return dict;
+
+            foreach (var key in nsDict.Keys)
+            {
+                var keyString = key.ToString();
+                if (keyString == null) continue;
+                dict[keyString] = ConvertNSObject(nsDict[key]);
+            }
+            return dict;
+        }
+
+        private static object? ConvertNSObject(NSObject? value)
+        {
+            return value switch
+            {
+                null => null,
+                NSString s => (string)s,
+                NSNumber n => n.DoubleValue,
+                NSDictionary d => ToManagedDictionary(d),
+                NSArray a => Enumerable.Range(0, (int)a.Count).Select(i => ConvertNSObject(a.GetItem<NSObject>((nuint)i))).ToList(),
+                _ => value.ToString()
+            };
         }
 
     }

--- a/src/Airship.Net/Platforms/iOS/Modules/AirshipMessageCenter.cs
+++ b/src/Airship.Net/Platforms/iOS/Modules/AirshipMessageCenter.cs
@@ -23,30 +23,6 @@ namespace AirshipDotNet.Platforms.iOS.Modules
             _module = module;
         }
 
-        internal class AirshipMessageCenterDisplayDelegate : global::Airship.UAMessageCenterDisplayDelegate
-        {
-            private readonly Action<string?> handler;
-
-            public AirshipMessageCenterDisplayDelegate(Action<string?> handler)
-            {
-                this.handler = handler;
-            }
-
-            public override void DisplayMessageCenterForMessageID(string messageId)
-            {
-                handler?.Invoke(messageId);
-            }
-
-            public override void DisplayMessageCenter()
-            {
-
-            }
-
-            public override void DismissMessageCenter()
-            {
-                handler?.Invoke(null);
-            }
-        }
 
         /// <summary>
         /// Gets all messages from the message center.
@@ -213,70 +189,6 @@ namespace AirshipDotNet.Platforms.iOS.Modules
             }
             var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
             return epoch.AddSeconds(date.SecondsSince1970);
-        }
-
-        private EventHandler<MessageCenterEventArgs>? onMessageCenterDisplay;
-        private AirshipMessageCenterDisplayDelegate? messageCenterDisplayDelegate;
-
-        /// <summary>
-        /// Add/remove the Message Center display listener.
-        /// </summary>
-        public event EventHandler<MessageCenterEventArgs> OnMessageCenterDisplay
-        {
-            add
-            {
-                onMessageCenterDisplay += value;
-                if (messageCenterDisplayDelegate == null)
-                {
-                    messageCenterDisplayDelegate = new AirshipMessageCenterDisplayDelegate((messageId) =>
-                    {
-                        onMessageCenterDisplay?.Invoke(this, new MessageCenterEventArgs(messageId));
-                    });
-                    UAirship.MessageCenter.WeakDisplayDelegate = messageCenterDisplayDelegate;
-                }
-            }
-            remove
-            {
-                onMessageCenterDisplay -= value;
-
-                if (onMessageCenterDisplay == null)
-                {
-                    UAirship.MessageCenter.WeakDisplayDelegate = null;
-                    messageCenterDisplayDelegate = null;
-                }
-            }
-        }
-
-        private EventHandler<EventArgs>? onMessagesUpdated;
-        private EventHandler<EventArgs>? airshipMessagesUpdatedHandler;
-
-        /// <summary>
-        /// Add/remove the Message Center updated listener.
-        /// </summary>
-        public event EventHandler<EventArgs> OnMessagesUpdated
-        {
-            add
-            {
-                onMessagesUpdated += value;
-                if (airshipMessagesUpdatedHandler == null)
-                {
-                    airshipMessagesUpdatedHandler = (sender, e) =>
-                    {
-                        onMessagesUpdated?.Invoke(this, e);
-                    };
-                    Airship.Instance.OnMessagesUpdated += airshipMessagesUpdatedHandler;
-                }
-            }
-            remove
-            {
-                onMessagesUpdated -= value;
-
-                if (onMessagesUpdated == null && airshipMessagesUpdatedHandler != null)
-                {
-                    Airship.Instance.OnMessagesUpdated -= airshipMessagesUpdatedHandler;
-                    airshipMessagesUpdatedHandler = null;
-                }
-            }
         }
 
     }


### PR DESCRIPTION
### What do these changes do?
Wire push, notification response, token, MC display/updated, and PC open events through AirshipEventEmitter on iOS and Android, and switch MauiSample to the new events.

This has breaking changes and would require a major release.

### Why are these changes necessary?
Brings the .NET plugin to event-type parity with Flutter and React Native so consumers can subscribe to the same set of typed events.

### How did you verify these changes?
Built MauiSample for the iOS simulator and exercised push enable, Message Center, and Preference Center on a live channel; events fired and no crashes.