### PR TITLE
Fix release workflow: bump Xcode to 26.2 for Swift 6.2 SDK compatibility

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,9 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+*"
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_16.0.app/Contents/Developer
+  # Xcode 26.2 required: AirshipWrapper contains Swift compiled against xcframeworks
+  # built with Swift 6.2.3. Xcode 16.0 (Swift 6.0) is incompatible.
+  DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: 1


### PR DESCRIPTION
The Release workflow was pinned to Xcode 16.0 (Swift 6.0), which cannot build AirshipWrapper because the Airship iOS xcframeworks are compiled with Swift 6.2.x. This matches the pin already used in ci.yaml.
